### PR TITLE
fix: Add missing RIN_GITHUB_CLIENT_ID and RIN_GITHUB_CLIENT_SECRET to…

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,6 +31,8 @@ jobs:
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          RIN_GITHUB_CLIENT_ID: ${{ secrets.RIN_GITHUB_CLIENT_ID }}
+          RIN_GITHUB_CLIENT_SECRET: ${{ secrets.RIN_GITHUB_CLIENT_SECRET }}
 
           DB_NAME: ${{ vars.DB_NAME }}
           WORKER_NAME: ${{ vars.WORKER_NAME }}


### PR DESCRIPTION
… deploy.yaml

This commit adds the RIN_GITHUB_CLIENT_ID and RIN_GITHUB_CLIENT_SECRET environment variables to the deploy.yaml file. These variables are necessary for authenticating with GitHub during the deployment process.