### PR TITLE
Add cursor pointer to Table of Contents links

### DIFF
--- a/client/src/hooks/useTableOfContents.tsx
+++ b/client/src/hooks/useTableOfContents.tsx
@@ -83,7 +83,7 @@ const useTableOfContents = (selector: string) => {
                 {tableOfContents.map((item) => (
                     <li
                         key={`toc$${item.index}`}
-                        className={`cursor-pointer hover:opacity-80 ${activeIndex === item.index ? "text-theme" : ""}`}
+                        className={`cursor-pointer hover:opacity-50 ${activeIndex === item.index ? "text-theme" : ""}`}
                         style={{ marginLeft: item.marginLeft }}
                         onClick={() => {
                             item.element.scrollIntoView({


### PR DESCRIPTION
Without the pointer cursor, the links looked like plain text, which could confuse users.  
This change aligns the behavior of the Table of Contents with standard link interactions.