### PR TITLE
fix Bun version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.13
 
       - name: Deploy
         env: # Or as an environment variable

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -111,6 +111,7 @@ S3_SECRET_ACCESS_KEY=<你的S3SecretAccessKey>
 
 > [!IMPORTANT]
 > 最后两行环境变量 `SKIP_DEPENDENCY_INSTALL` 和 `UNSTABLE_PRE_BUILD` 为配置 Cloudflare 使用 Bun 进行构建的参数，不要修改
+Bun 的版本要低于 1.3.0，可以是 1.2.13 或 1.2.15
 
 ```ini
 NAME=Xeu # 昵称，显示在左上角
@@ -119,7 +120,7 @@ AVATAR=https://avatars.githubusercontent.com/u/36541432 # 头像地址，显示�
 API_URL=https://rin.xeu.life # 服务端域名，可以先使用默认值查看效果，后续部署服务端后再修改
 PAGE_SIZE=5 # 默认分页大小，推荐 5
 SKIP_DEPENDENCY_INSTALL=true
-UNSTABLE_PRE_BUILD=asdf install bun latest && asdf global bun latest && bun i
+UNSTABLE_PRE_BUILD=asdf install bun 1.2.13 && asdf global bun 1.2.13 && bun i
 ```
 
 ![1000000660](https://github.com/openRin/Rin/assets/36541432/0fe9276f-e16f-4b8a-87c5-14de582c9a3a)


### PR DESCRIPTION
[fix] 问题描述 前端部署失败 #388
https://github.com/openRin/Rin/issues/388

Cloudflare pages 前置 adsf 安装 最新版本 bun v1.3.0 在workspaces / monorepo Isolated installs（隔离安装 / 分离安装）成为默认，而旧版本的 Bun 在 monorepo / workspaces 中更倾向于 hoisted install（类似 npm / yarn 的扁平 node_modules 机制）或混合机制。
      rin 项目中使用的是旧版本的 bun ,且利用了 monorepo / workspaces 的 hoisted install，因此安装 bun v1.3.0 会导致运行脚本时某些包安装的位置不对而找不到包