### PR TITLE
fix: hide UV/PV stats when disabled

### DIFF
--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -13,7 +13,7 @@ function Footer() {
     const [modeState, setModeState] = useState<ThemeMode>('system');
     const config = useContext(ClientConfigContext);
     const footerHtml = config.get<string>('footer');
-    const loginEnabled = config.get<boolean>('login.enabled');
+    const loginEnabled = config.getBoolean('login.enabled');
     const [doubleClickTimes, setDoubleClickTimes] = useState(0);
     useEffect(() => {
         const mode = localStorage.getItem('theme') as ThemeMode || 'system';
@@ -61,7 +61,7 @@ function Footer() {
                     }}>
                         © {new Date().getFullYear()} Powered by <a className='hover:underline' href="https://github.com/openRin/Rin" target="_blank">Rin</a>
                     </span>
-                    {config.get<boolean>('rss') && <>
+                    {config.getBoolean('rss') && <>
                         <Spliter />
                         <Popup trigger={
                             <button className="hover:underline" type="button">

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -255,7 +255,7 @@ function UserAvatar({ className, profile }: { className?: string, profile?: Prof
     const [isOpen, setIsOpen] = useState(false);
 
     return (
-        <> {config.get<boolean>('login.enabled') && <div className={className + " flex flex-row items-center"}>
+        <> {config.getBoolean('login.enabled') && <div className={className + " flex flex-row items-center"}>
             {profile ? <>
                 <Popup
                     arrow={false}

--- a/client/src/page/feed.tsx
+++ b/client/src/page/feed.tsx
@@ -43,7 +43,7 @@ export function FeedPage({ id, TOC, clean }: { id: string, TOC: () => JSX.Elemen
   const { showConfirm, ConfirmUI } = useConfirm();
   const [top, setTop] = useState<number>(0);
   const config = useContext(ClientConfigContext);
-  const counterEnabled = config.get<boolean>('counter.enabled');
+  const counterEnabled = config.getBoolean('counter.enabled');
   const hasAISummary = Boolean(feed?.ai_summary?.trim());
   const showAISummaryState = feed?.ai_summary_status === "pending" || feed?.ai_summary_status === "processing" || feed?.ai_summary_status === "failed";
   function deleteFeed() {
@@ -477,7 +477,7 @@ function Comments({ id }: { id: string }) {
   }, [id]);
   return (
     <>
-      {config.get<boolean>('comment.enabled') &&
+      {config.getBoolean('comment.enabled') &&
         <div className="m-2 flex flex-col justify-center items-center">
           <CommentInput id={id} onRefresh={loadComments} />
           {error && (

--- a/client/src/page/settings.tsx
+++ b/client/src/page/settings.tsx
@@ -195,7 +195,7 @@ export function Settings() {
           <ItemSwitch
             title={t("settings.login.enable.title")}
             description={t("settings.login.enable.desc", { url: oauth_url })}
-            checked={Boolean(clientConfig.get("login.enabled"))}
+            checked={clientConfig.getBoolean("login.enabled")}
             onChange={(checked) => {
               setConfigValue("client", "login.enabled", checked);
             }}
@@ -203,7 +203,7 @@ export function Settings() {
           <ItemSwitch
             title={t("settings.comment.enable.title")}
             description={t("settings.comment.enable.desc")}
-            checked={Boolean(clientConfig.get("comment.enabled"))}
+            checked={clientConfig.getBoolean("comment.enabled")}
             onChange={(checked) => {
               setConfigValue("client", "comment.enabled", checked);
             }}
@@ -211,7 +211,7 @@ export function Settings() {
           <ItemSwitch
             title={t("settings.counter.enable.title")}
             description={t("settings.counter.enable.desc")}
-            checked={Boolean(clientConfig.get("counter.enabled"))}
+            checked={clientConfig.getBoolean("counter.enabled")}
             onChange={(checked) => {
               setConfigValue("client", "counter.enabled", checked);
             }}
@@ -219,7 +219,7 @@ export function Settings() {
           <ItemSwitch
             title={t("settings.rss.title")}
             description={t("settings.rss.desc")}
-            checked={Boolean(clientConfig.get("rss"))}
+            checked={clientConfig.getBoolean("rss")}
             onChange={(checked) => {
               setConfigValue("client", "rss", checked);
             }}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -77,4 +77,30 @@ export class ConfigWrapper {
   default<T>(key: string) {
     return this.defaultConfig.get(key) as T;
   }
+
+  getBoolean(key: string) {
+    const value = this.get<unknown>(key);
+
+    if (typeof value === "boolean") {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      const normalizedValue = value.trim().toLowerCase();
+
+      if (normalizedValue === "true") {
+        return true;
+      }
+
+      if (normalizedValue === "false") {
+        return false;
+      }
+    }
+
+    if (typeof value === "number") {
+      return value !== 0;
+    }
+
+    return Boolean(value);
+  }
 }


### PR DESCRIPTION
## Summary
- add a shared boolean config reader to normalize string and boolean values
- hide feed UV/PV and other toggle-based UI with normalized boolean checks
- ensure settings switches reflect stored boolean-like values correctly

## Testing
- bun run check
- bun run test