### PR TITLE
docs: remove workers route setup for rss

### DIFF
--- a/docs/docs/en/guide/rss.md
+++ b/docs/docs/en/guide/rss.md
@@ -15,31 +15,13 @@ RSS_DESCRIPTION=<RSS description, defaults to Feed from Rin>
 
 You can add these environment variables in GitHub under `Settings` > `Secrets and Variables` > `Actions` > `Variables` > `New repository variable`.
 
-### Workers Routes
+## Usage
 
-In the Cloudflare Workers panel, open the details page of your domain, click `Workers Routes`, and add a new route. The route should be:
-
-```
-<frontend domain>/*
-```
-
-For example:
-
-```
-xeu.life/*
-```
+RSS no longer requires any extra Workers route configuration. After deployment, you can access the feed endpoints directly.
 
 :::note
 Note: RSS subscription paths have been moved from `/sub/` to the root path. The old `/sub/` paths remain available for backward compatibility.
 :::
-
-Select the Worker you deployed, and click save.
-
-:::note
-If you have also configured domestic CDN acceleration, you will need to set the Workers route for the origin domain in the same way as described above.
-:::
-
-## Usage
 
 The subscription address for RSS is:
 

--- a/docs/docs/zh/guide/rss.md
+++ b/docs/docs/zh/guide/rss.md
@@ -13,32 +13,13 @@ RSS_DESCRIPTION=<RSS 描述，默认为 Feed from Rin>
 
 以上环境变量通过在 Github 的 `Settings` > `Secrets and Variables` > `Actions` > `Variables` > `New repository variable` 中添加即可。
 
-## Workers 路由
+## 使用
 
-在 Cloudflare Workers 面板中打开自己的域名详情页，点击 `Workers 路由`，添加一个新路由，路由填写为：
-
-```
-<前端域名>/*
-```
-
-如：
-
-```
-xeu.life/*
-```
+RSS 现在不需要额外配置 Workers 路由，部署完成后即可直接访问订阅地址。
 
 :::note
 注意：RSS 订阅地址已经从 `/sub/` 路径迁移到根路径，旧的 `/sub/` 路径仍然可用以保持向后兼容。
 :::
-
-Worker 选择为部署的 Worker，点击保存。
-
-:::note
-如果你还配置了国内 CDN 加速，还需要将回源域名按上述同样的方式设置 Workers 路由。
-:::
-
-
-## 使用
 
 RSS 的订阅地址为：
 


### PR DESCRIPTION
## Summary
- remove Workers route setup instructions from the RSS docs
- clarify that RSS feed endpoints work without extra Workers route configuration
- keep the legacy /sub/ compatibility note in both locales