### PR TITLE
fix: resolve webhook config consistently

### DIFF
--- a/server/src/services/__tests__/config-helpers.test.ts
+++ b/server/src/services/__tests__/config-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
 import type { Database } from "bun:sqlite";
-import { buildServerConfigResponse } from "../config-helpers";
+import { buildServerConfigResponse, resolveWebhookConfig } from "../config-helpers";
 import { cleanupTestDB, createMockDB } from "../../../tests/fixtures";
 
 describe("buildServerConfigResponse", () => {
@@ -62,5 +62,47 @@ describe("buildServerConfigResponse", () => {
         });
 
         expect(response["webhook_url"]).toBe("https://stored.example.com/webhook");
+    });
+});
+
+describe("resolveWebhookConfig", () => {
+    it("prefers stored webhook_url over the legacy key and env fallback", async () => {
+        const config = await resolveWebhookConfig({
+            async get(key: string) {
+                if (key === "webhook_url") {
+                    return "https://stored.example.com/webhook";
+                }
+                if (key === "WEBHOOK_URL") {
+                    return "https://legacy.example.com/webhook";
+                }
+                return undefined;
+            },
+        }, {
+            WEBHOOK_URL: "https://env.example.com/webhook",
+        });
+
+        expect(config.webhookUrl).toBe("https://stored.example.com/webhook");
+    });
+
+    it("uses body overrides before stored config values", async () => {
+        const config = await resolveWebhookConfig({
+            async get(key: string) {
+                if (key === "webhook_url") {
+                    return "https://stored.example.com/webhook";
+                }
+                if (key === "webhook.method") {
+                    return "POST";
+                }
+                return undefined;
+            },
+        }, {
+            WEBHOOK_URL: "https://env.example.com/webhook",
+        }, {
+            webhook_url: "https://override.example.com/webhook",
+            "webhook.method": "GET",
+        });
+
+        expect(config.webhookUrl).toBe("https://override.example.com/webhook");
+        expect(config.webhookMethod).toBe("GET");
     });
 });

--- a/server/src/services/comments.ts
+++ b/server/src/services/comments.ts
@@ -2,8 +2,8 @@ import { Hono } from "hono";
 import type { AppContext } from "../core/hono-types";
 import { desc, eq } from "drizzle-orm";
 import { comments, feeds, users } from "../db/schema";
-import { WEBHOOK_URL_KEY } from "../utils/config";
 import { notify } from "../utils/webhook";
+import { resolveWebhookConfig } from "./config-helpers";
 
 export function CommentService(): Hono {
     const app = new Hono();
@@ -62,14 +62,16 @@ export function CommentService(): Hono {
             content
         });
 
-        const webhookUrl = await serverConfig.get(WEBHOOK_URL_KEY) || env.WEBHOOK_URL;
-        const webhookMethod = await serverConfig.get("webhook.method") as string | undefined;
-        const webhookContentType = await serverConfig.get("webhook.content_type") as string | undefined;
-        const webhookHeaders = await serverConfig.get("webhook.headers") as string | undefined;
-        const webhookBodyTemplate = await serverConfig.get("webhook.body_template") as string | undefined;
+        const {
+            webhookUrl,
+            webhookMethod,
+            webhookContentType,
+            webhookHeaders,
+            webhookBodyTemplate,
+        } = await resolveWebhookConfig(serverConfig, env);
         const frontendUrl = new URL(c.req.url).origin;
         await notify(
-            webhookUrl,
+            webhookUrl || "",
             {
                 event: "comment.created",
                 message: `${frontendUrl}/feed/${feedId}\n${user.username} 评论了: ${exist.title}\n${content}`,

--- a/server/src/services/config-helpers.ts
+++ b/server/src/services/config-helpers.ts
@@ -12,8 +12,32 @@ type ConfigMapLike = {
   save(): Promise<void>;
 };
 
+type ConfigReaderLike = {
+  get(key: string): Promise<unknown>;
+};
+
 type ServerConfigResponseEnv = {
   WEBHOOK_URL?: string;
+};
+
+type WebhookConfigOverrides = {
+  webhook_url?: string;
+  "webhook.method"?: string;
+  "webhook.content_type"?: string;
+  "webhook.headers"?: string | Record<string, unknown>;
+  "webhook.body_template"?: string | Record<string, unknown>;
+};
+
+type WebhookConfigEnv = {
+  WEBHOOK_URL?: string;
+};
+
+export type ResolvedWebhookConfig = {
+  webhookUrl?: string;
+  webhookMethod?: string;
+  webhookContentType?: string;
+  webhookHeaders?: string | Record<string, unknown>;
+  webhookBodyTemplate?: string | Record<string, unknown>;
 };
 
 export type ConfigTypeParam = "client" | "server";
@@ -58,6 +82,66 @@ function normalizeWebhookConfigResponse(config: Record<string, unknown>) {
 
 export function isAIConfigKey(key: string): boolean {
   return AI_CONFIG_KEYS.some((candidate) => candidate === key) || key.startsWith("ai_summary.");
+}
+
+function normalizeOptionalString(value: unknown) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeWebhookTemplateConfigValue(value: unknown) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+
+  return undefined;
+}
+
+export async function resolveWebhookConfig(
+  serverConfig: ConfigReaderLike,
+  env?: WebhookConfigEnv,
+  overrides: WebhookConfigOverrides = {},
+): Promise<ResolvedWebhookConfig> {
+  const [
+    storedWebhookUrl,
+    legacyWebhookUrl,
+    webhookMethod,
+    webhookContentType,
+    webhookHeaders,
+    webhookBodyTemplate,
+  ] = await Promise.all([
+    serverConfig.get("webhook_url"),
+    serverConfig.get(WEBHOOK_URL_KEY),
+    serverConfig.get("webhook.method"),
+    serverConfig.get("webhook.content_type"),
+    serverConfig.get("webhook.headers"),
+    serverConfig.get("webhook.body_template"),
+  ]);
+
+  return {
+    webhookUrl:
+      normalizeOptionalString(overrides.webhook_url) ??
+      normalizeOptionalString(storedWebhookUrl) ??
+      normalizeOptionalString(legacyWebhookUrl) ??
+      normalizeOptionalString(env?.WEBHOOK_URL),
+    webhookMethod: normalizeOptionalString(overrides["webhook.method"]) ?? normalizeOptionalString(webhookMethod),
+    webhookContentType:
+      normalizeOptionalString(overrides["webhook.content_type"]) ?? normalizeOptionalString(webhookContentType),
+    webhookHeaders:
+      normalizeWebhookTemplateConfigValue(overrides["webhook.headers"]) ??
+      normalizeWebhookTemplateConfigValue(webhookHeaders),
+    webhookBodyTemplate:
+      normalizeWebhookTemplateConfigValue(overrides["webhook.body_template"]) ??
+      normalizeWebhookTemplateConfigValue(webhookBodyTemplate),
+  };
 }
 
 export function splitConfigPayload(body: Record<string, unknown>) {

--- a/server/src/services/config.ts
+++ b/server/src/services/config.ts
@@ -3,7 +3,6 @@ import { wrapTime } from "hono/timing";
 import type { AppContext } from "../core/hono-types";
 import { getAIConfigForFrontend, setAIConfig, getAIConfig } from "../utils/db-config";
 import { testAIModel } from "../utils/ai";
-import { WEBHOOK_URL_KEY } from "../utils/config";
 import { notify } from "../utils/webhook";
 import {
     buildCombinedConfigResponse,
@@ -11,6 +10,7 @@ import {
     buildServerConfigResponse,
     isConfigType,
     persistRegularConfig,
+    resolveWebhookConfig,
     splitConfigPayload,
 } from "./config-helpers";
 import { buildHealthCheckResponse } from "./config-health";
@@ -75,23 +75,18 @@ export function ConfigService(): Hono {
             test_message?: string;
         };
 
-        const [storedWebhookUrl, webhookMethod, webhookContentType, webhookHeaders, webhookBodyTemplate] = await wrapTime(
+        const {
+            webhookUrl,
+            webhookMethod: resolvedWebhookMethod,
+            webhookContentType: resolvedWebhookContentType,
+            webhookHeaders: resolvedWebhookHeaders,
+            webhookBodyTemplate: resolvedWebhookBodyTemplate,
+        } = await wrapTime(
             c,
             'webhook_config',
-            Promise.all([
-                serverConfig.get(WEBHOOK_URL_KEY),
-                serverConfig.get("webhook.method"),
-                serverConfig.get("webhook.content_type"),
-                serverConfig.get("webhook.headers"),
-                serverConfig.get("webhook.body_template"),
-            ]),
+            resolveWebhookConfig(serverConfig, env, body),
             'Load webhook config',
-        ) as Array<string | undefined>;
-        const webhookUrl = body.webhook_url ?? storedWebhookUrl ?? env.WEBHOOK_URL;
-        const resolvedWebhookMethod = body["webhook.method"] ?? webhookMethod;
-        const resolvedWebhookContentType = body["webhook.content_type"] ?? webhookContentType;
-        const resolvedWebhookHeaders = body["webhook.headers"] ?? webhookHeaders;
-        const resolvedWebhookBodyTemplate = body["webhook.body_template"] ?? webhookBodyTemplate;
+        );
         const frontendUrl = new URL(c.req.url).origin;
         const testMessage = body.test_message?.trim() || "This is a test webhook message from Rin settings.";
 

--- a/server/src/services/friends.ts
+++ b/server/src/services/friends.ts
@@ -4,8 +4,8 @@ import type { AppContext, DB } from "../core/hono-types";
 import * as schema from "../db/schema";
 import { friends } from "../db/schema";
 import type { CacheImpl } from "../utils/cache";
-import { WEBHOOK_URL_KEY } from "../utils/config";
 import { notify } from "../utils/webhook";
+import { resolveWebhookConfig } from "./config-helpers";
 
 export function FriendService(): Hono {
     const app = new Hono();
@@ -77,15 +77,17 @@ export function FriendService(): Hono {
         });
 
         if (!admin) {
-            const webhookUrl = await serverConfig.get(WEBHOOK_URL_KEY) || env.WEBHOOK_URL;
-            const webhookMethod = await serverConfig.get("webhook.method") as string | undefined;
-            const webhookContentType = await serverConfig.get("webhook.content_type") as string | undefined;
-            const webhookHeaders = await serverConfig.get("webhook.headers") as string | undefined;
-            const webhookBodyTemplate = await serverConfig.get("webhook.body_template") as string | undefined;
+            const {
+                webhookUrl,
+                webhookMethod,
+                webhookContentType,
+                webhookHeaders,
+                webhookBodyTemplate,
+            } = await resolveWebhookConfig(serverConfig, env);
             const frontendUrl = new URL(c.req.url).origin;
             const content = `${frontendUrl}/friends\n${username} 申请友链: ${name}\n${desc}\n${url}`;
             await notify(
-                webhookUrl,
+                webhookUrl || "",
                 {
                     event: "friend.created",
                     message: content,
@@ -159,15 +161,17 @@ export function FriendService(): Hono {
         }).where(eq(friends.id, parseInt(id)));
         
         if (!admin) {
-            const webhookUrl = await serverConfig.get(WEBHOOK_URL_KEY) || env.WEBHOOK_URL;
-            const webhookMethod = await serverConfig.get("webhook.method") as string | undefined;
-            const webhookContentType = await serverConfig.get("webhook.content_type") as string | undefined;
-            const webhookHeaders = await serverConfig.get("webhook.headers") as string | undefined;
-            const webhookBodyTemplate = await serverConfig.get("webhook.body_template") as string | undefined;
+            const {
+                webhookUrl,
+                webhookMethod,
+                webhookContentType,
+                webhookHeaders,
+                webhookBodyTemplate,
+            } = await resolveWebhookConfig(serverConfig, env);
             const frontendUrl = new URL(c.req.url).origin;
             const content = `${frontendUrl}/friends\n${username} 更新友链: ${name}\n${desc}\n${url}`;
             await notify(
-                webhookUrl,
+                webhookUrl || "",
                 {
                     event: "friend.updated",
                     message: content,


### PR DESCRIPTION
## Summary
- unify webhook config resolution for runtime notifications and the settings test endpoint
- prefer stored webhook_url values while still supporting legacy and env fallbacks
- add regression coverage for webhook config priority resolution

Closes #470