### PR TITLE
fix: ignore comment webhook delivery errors

### DIFF
--- a/server/src/services/__tests__/comments.test.ts
+++ b/server/src/services/__tests__/comments.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { CommentService } from '../comments';
 import { Hono } from "hono";
 import type { Variables } from "../../core/hono-types";
@@ -10,6 +10,7 @@ describe('CommentService', () => {
     let sqlite: Database;
     let env: Env;
     let app: Hono<{ Bindings: Env; Variables: Variables }>;
+    const originalFetch = globalThis.fetch;
 
     beforeEach(async () => {
         const ctx = await setupTestApp(CommentService);
@@ -23,6 +24,7 @@ describe('CommentService', () => {
     });
 
     afterEach(() => {
+        globalThis.fetch = originalFetch;
         cleanupTestDB(sqlite);
     });
 
@@ -167,6 +169,27 @@ describe('CommentService', () => {
             }, env);
 
             expect(res.status).toBe(400);
+        });
+
+        it('should still create the comment when webhook delivery fails', async () => {
+            env.WEBHOOK_URL = 'not-a-valid-url' as any;
+            globalThis.fetch = mock(async () => {
+                throw new TypeError('Invalid URL');
+            }) as typeof fetch;
+
+            const res = await app.request('/1', {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer mock_token_1',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ content: 'Comment survives webhook errors' }),
+            }, env);
+
+            expect(res.status).toBe(200);
+
+            const comments = sqlite.prepare(`SELECT * FROM comments WHERE feed_id = 1`).all();
+            expect(comments.length).toBe(3);
         });
     });
 

--- a/server/src/services/comments.ts
+++ b/server/src/services/comments.ts
@@ -70,23 +70,27 @@ export function CommentService(): Hono {
             webhookBodyTemplate,
         } = await resolveWebhookConfig(serverConfig, env);
         const frontendUrl = new URL(c.req.url).origin;
-        await notify(
-            webhookUrl || "",
-            {
-                event: "comment.created",
-                message: `${frontendUrl}/feed/${feedId}\n${user.username} 评论了: ${exist.title}\n${content}`,
-                title: exist.title || "",
-                url: `${frontendUrl}/feed/${feedId}`,
-                username: user.username,
-                content,
-            },
-            {
-                method: webhookMethod,
-                contentType: webhookContentType,
-                headers: webhookHeaders,
-                bodyTemplate: webhookBodyTemplate,
-            },
-        );
+        try {
+            await notify(
+                webhookUrl || "",
+                {
+                    event: "comment.created",
+                    message: `${frontendUrl}/feed/${feedId}\n${user.username} 评论了: ${exist.title}\n${content}`,
+                    title: exist.title || "",
+                    url: `${frontendUrl}/feed/${feedId}`,
+                    username: user.username,
+                    content,
+                },
+                {
+                    method: webhookMethod,
+                    contentType: webhookContentType,
+                    headers: webhookHeaders,
+                    bodyTemplate: webhookBodyTemplate,
+                },
+            );
+        } catch (error) {
+            console.error("Failed to send comment webhook", error);
+        }
         return c.text('OK');
     });
 


### PR DESCRIPTION
## Summary
- keep comment creation successful even when webhook delivery fails
- log webhook delivery failures instead of returning Invalid URL to the client
- add regression coverage for failed comment webhook delivery
