### PR TITLE
fix: gate public cache inside cache impl

### DIFF
--- a/server/src/core/hono-middleware.ts
+++ b/server/src/core/hono-middleware.ts
@@ -51,7 +51,11 @@ export const initContainerMiddleware = createMiddleware<{
 
         const cache = await container.get('cache', async () => profileAsync(c, "init_cache", async () => {
             const { CacheImpl } = await import('../utils/cache');
-            return new CacheImpl(db, c.env, "cache");
+            const clientConfig = await container.get('clientConfig', async () => profileAsync(c, "init_client_config", async () => {
+                const { CacheImpl } = await import('../utils/cache');
+                return new CacheImpl(db, c.env, "client.config");
+            }));
+            return new CacheImpl(db, c.env, "cache", undefined, clientConfig);
         }));
 
         const serverConfig = await container.get('serverConfig', async () => profileAsync(c, "init_server_config", async () => {
@@ -87,8 +91,7 @@ export const initContainerMiddleware = createMiddleware<{
         }
 
         c.set('db', db);
-        const { ConditionalCacheImpl } = await import('../utils/cache');
-        c.set('cache', new ConditionalCacheImpl(cache, clientConfig));
+        c.set('cache', cache);
         c.set('serverConfig', serverConfig);
         c.set('clientConfig', clientConfig);
         c.set('jwt', jwt);

--- a/server/src/runtime/queue-handler.ts
+++ b/server/src/runtime/queue-handler.ts
@@ -1,5 +1,5 @@
 import { drizzle } from "drizzle-orm/d1";
-import { CacheImpl, ConditionalCacheImpl } from "../utils/cache";
+import { CacheImpl } from "../utils/cache";
 import { isQueueTask, FEED_AI_SUMMARY_TASK } from "../queue";
 import { processFeedAISummaryTask } from "../services/feed-ai-summary";
 import { clearFeedCache } from "../services/feed";
@@ -11,10 +11,9 @@ export async function handleQueue(
 ) {
   const schema = await import("../db/schema");
   const db = drizzle(env.DB, { schema });
-  const rawCache = new CacheImpl(db, env, "cache");
   const serverConfig = new CacheImpl(db, env, "server.config", "database");
   const clientConfig = new CacheImpl(db, env, "client.config", "database");
-  const cache = new ConditionalCacheImpl(rawCache, clientConfig);
+  const cache = new CacheImpl(db, env, "cache", undefined, clientConfig);
 
   for (const message of batch.messages) {
     const body = message.body;

--- a/server/src/runtime/scheduled-handler.ts
+++ b/server/src/runtime/scheduled-handler.ts
@@ -1,5 +1,5 @@
 import { drizzle } from "drizzle-orm/d1";
-import { CacheImpl, ConditionalCacheImpl } from "../utils/cache";
+import { CacheImpl } from "../utils/cache";
 
 export async function handleScheduled(
   _controller: ScheduledController | null,
@@ -9,10 +9,9 @@ export async function handleScheduled(
   const schema = await import("../db/schema");
   const db = drizzle(env.DB, { schema });
 
-  const rawCache = new CacheImpl(db, env, "cache");
   const serverConfig = new CacheImpl(db, env, "server.config", "database");
   const clientConfig = new CacheImpl(db, env, "client.config");
-  const cache = new ConditionalCacheImpl(rawCache, clientConfig);
+  const cache = new CacheImpl(db, env, "cache", undefined, clientConfig);
 
   const { friendCrontab } = await import("../services/friends");
   const { rssCrontab } = await import("../services/rss");

--- a/server/src/utils/__tests__/cache.test.ts
+++ b/server/src/utils/__tests__/cache.test.ts
@@ -3,7 +3,6 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import {
     CacheImpl,
-    ConditionalCacheImpl,
     createPublicCache,
     createServerConfig,
     createClientConfig,
@@ -689,7 +688,7 @@ describe('CacheImpl - getOrSet 和 getOrDefault', () => {
     });
 });
 
-describe('ConditionalCacheImpl', () => {
+describe('CacheImpl - 公共缓存开关', () => {
     let { db, sqlite } = createTestDB();
     let mockEnv: Env;
     let cacheImpl: CacheImpl;
@@ -709,27 +708,36 @@ describe('ConditionalCacheImpl', () => {
     });
 
     it('默认关闭时不读取或写入公共缓存', async () => {
-        await cacheImpl.set('feed_1', { title: 'cached' });
-        const conditionalCache = new ConditionalCacheImpl(cacheImpl, clientConfig);
+        const seededCache = new CacheImpl(db as any, mockEnv, 'cache', 'database');
+        await seededCache.set('feed_1', { title: 'cached' });
+        cacheImpl = new CacheImpl(db as any, mockEnv, 'cache', 'database', clientConfig);
 
-        expect(await conditionalCache.get('feed_1')).toBeNull();
+        expect(await cacheImpl.get('feed_1')).toBeNull();
 
         let computed = false;
-        const value = await conditionalCache.getOrSet('feed_1', async () => {
+        const value = await cacheImpl.getOrSet('feed_1', async () => {
             computed = true;
             return { title: 'fresh' };
         });
 
         expect(computed).toBe(true);
         expect(value).toEqual({ title: 'fresh' });
-        expect(await cacheImpl.get('feed_1')).toEqual({ title: 'cached' });
+        expect(await seededCache.get('feed_1')).toEqual({ title: 'cached' });
     });
 
     it('启用后应正常命中公共缓存', async () => {
         await clientConfig.set('cache.enabled', true);
         await cacheImpl.set('feed_1', { title: 'cached' });
 
-        const conditionalCache = new ConditionalCacheImpl(cacheImpl, clientConfig);
-        expect(await conditionalCache.get('feed_1')).toEqual({ title: 'cached' });
+        const enabledCache = new CacheImpl(db as any, mockEnv, 'cache', 'database', clientConfig);
+        expect(await enabledCache.get('feed_1')).toEqual({ title: 'cached' });
+    });
+
+    it('client.config 不应受公共缓存开关影响', async () => {
+        await clientConfig.set('cache.enabled', false);
+        await clientConfig.set('site.name', 'Rin Test');
+
+        const freshClientConfig = new CacheImpl(db as any, mockEnv, 'client.config', 'database');
+        expect(await freshClientConfig.get('site.name')).toBe('Rin Test');
     });
 });

--- a/server/src/utils/cache.ts
+++ b/server/src/utils/cache.ts
@@ -11,19 +11,6 @@ type CacheConfigReader = {
     getOrDefault<T>(key: string, defaultValue: T): Promise<T>;
 };
 
-type CacheDelegate = {
-    get(key: string): Promise<any | null>;
-    set(key: string, value: any, save?: boolean): Promise<void>;
-    delete(key: string, save?: boolean): Promise<void>;
-    deletePrefix(prefix: string): Promise<void>;
-    getOrSet<T>(key: string, factory: () => Promise<T>): Promise<T>;
-    getOrDefault<T>(key: string, defaultValue: T): Promise<T>;
-    getBySuffix(suffix: string): Promise<any[]>;
-    all(): Promise<Map<string, any>>;
-    save(): Promise<void>;
-    clear(): Promise<void>;
-};
-
 function normalizeCacheEnabled(value: unknown) {
     if (typeof value === "boolean") {
         return value;
@@ -220,8 +207,16 @@ export class CacheImpl {
     type: string;
     loaded: boolean = false;
     private storageProvider: StorageProvider;
+    private cacheEnabled: Promise<boolean> | null = null;
+    private configReader?: CacheConfigReader;
 
-    constructor(db: DB, env: Env, type: string = "cache", storageMode?: CacheStorageMode) {
+    constructor(
+        db: DB,
+        env: Env,
+        type: string = "cache",
+        storageMode?: CacheStorageMode,
+        configReader?: CacheConfigReader,
+    ) {
         // 确保 type 不为空，防止不同类型共享同一个存储位置
         if (!type || type.trim() === '') {
             throw new Error('Cache type cannot be empty');
@@ -230,6 +225,7 @@ export class CacheImpl {
         this.db = db;
         this.env = env;
         this.cache = new Map<string, any>();
+        this.configReader = configReader;
 
         // 优先级：参数 > 环境变量，默认为 s3 以向前兼容
         const mode = storageMode ?? (env.CACHE_STORAGE_MODE as CacheStorageMode) ?? 's3';
@@ -242,12 +238,34 @@ export class CacheImpl {
         }
     }
 
+    private async isEnabled() {
+        // Only the public content cache is gated by `cache.enabled`.
+        // Config stores must stay readable, otherwise `cache -> client.config`
+        // would recurse back into the same gate and break initialization.
+        if (this.type !== "cache") {
+            return true;
+        }
+
+        if (!this.configReader) {
+            return true;
+        }
+
+        if (!this.cacheEnabled) {
+            this.cacheEnabled = isPublicCacheEnabled(this.configReader);
+        }
+
+        return this.cacheEnabled;
+    }
+
     async load() {
         await this.storageProvider.load();
         this.loaded = true;
     }
 
     async all() {
+        if (!(await this.isEnabled())) {
+            return new Map<string, any>();
+        }
         if (!this.loaded) {
             await this.load();
         }
@@ -255,6 +273,9 @@ export class CacheImpl {
     }
 
     async get(key: string) {
+        if (!(await this.isEnabled())) {
+            return null;
+        }
         if (!this.loaded) {
             await this.load();
         }
@@ -262,6 +283,9 @@ export class CacheImpl {
     }
 
     async getByPrefix(prefix: string): Promise<any[]> {
+        if (!(await this.isEnabled())) {
+            return [];
+        }
         if (!this.loaded) {
             await this.load();
         }
@@ -275,6 +299,9 @@ export class CacheImpl {
     }
 
     async getBySuffix(suffix: string): Promise<any[]> {
+        if (!(await this.isEnabled())) {
+            return [];
+        }
         if (!this.loaded) {
             await this.load();
         }
@@ -288,6 +315,9 @@ export class CacheImpl {
     }
 
     async getOrSet<T>(key: string, value: () => Promise<T>) {
+        if (!(await this.isEnabled())) {
+            return value();
+        }
         const cached = await this.get(key);
         if (cached !== undefined) {
             console.log('Cache hit', key);
@@ -300,10 +330,16 @@ export class CacheImpl {
     }
 
     async getOrDefault<T>(key: string, defaultValue: T) {
+        if (!(await this.isEnabled())) {
+            return defaultValue;
+        }
         return this.getOrSet(key, async () => defaultValue);
     }
 
     async set(key: string, value: any, save: boolean = true) {
+        if (!(await this.isEnabled())) {
+            return;
+        }
         if (!this.loaded)
             await this.load();
         this.cache.set(key, value);
@@ -360,83 +396,6 @@ export class CacheImpl {
         const dbProvider = new DatabaseStorageProvider(this.db, this.cache, this.type);
         await dbProvider.save();
         console.log('Migration completed');
-    }
-}
-
-export class ConditionalCacheImpl {
-    private enabled: Promise<boolean> | null = null;
-
-    constructor(
-        private cache: CacheDelegate,
-        private clientConfig: CacheConfigReader,
-    ) {}
-
-    private async isEnabled() {
-        if (!this.enabled) {
-            this.enabled = isPublicCacheEnabled(this.clientConfig);
-        }
-        return this.enabled;
-    }
-
-    async get(key: string) {
-        if (!(await this.isEnabled())) {
-            return null;
-        }
-        return this.cache.get(key);
-    }
-
-    async set(key: string, value: any, save?: boolean) {
-        if (!(await this.isEnabled())) {
-            return;
-        }
-        await this.cache.set(key, value, save);
-    }
-
-    async delete(key: string, save?: boolean) {
-        await this.cache.delete(key, save);
-    }
-
-    async deletePrefix(prefix: string) {
-        await this.cache.deletePrefix(prefix);
-    }
-
-    async getOrSet<T>(key: string, factory: () => Promise<T>) {
-        if (!(await this.isEnabled())) {
-            return factory();
-        }
-        return this.cache.getOrSet(key, factory);
-    }
-
-    async getOrDefault<T>(key: string, defaultValue: T) {
-        if (!(await this.isEnabled())) {
-            return defaultValue;
-        }
-        return this.cache.getOrDefault(key, defaultValue);
-    }
-
-    async getBySuffix(suffix: string) {
-        if (!(await this.isEnabled())) {
-            return [];
-        }
-        return this.cache.getBySuffix(suffix);
-    }
-
-    async all() {
-        if (!(await this.isEnabled())) {
-            return new Map<string, any>();
-        }
-        return this.cache.all();
-    }
-
-    async save() {
-        if (!(await this.isEnabled())) {
-            return;
-        }
-        await this.cache.save();
-    }
-
-    async clear() {
-        await this.cache.clear();
     }
 }
 

--- a/server/tests/fixtures/index.ts
+++ b/server/tests/fixtures/index.ts
@@ -8,7 +8,6 @@ import * as schema from '../../src/db/schema';
 import type { Variables, JWTUtils, OAuth2Utils, CacheImpl } from '../../src/core/hono-types';
 import { profileAsync } from '../../src/core/server-timing';
 import { users } from '../../src/db/schema';
-import { ConditionalCacheImpl } from '../../src/utils/cache';
 
 /**
  * Create an in-memory test database with Drizzle ORM
@@ -202,12 +201,43 @@ export function cleanupTestDB(sqlite: Database) {
  */
 export class TestCacheImpl implements CacheImpl {
     private data = new Map<string, any>();
+    private clientConfig?: TestCacheImpl;
+
+    constructor(clientConfig?: TestCacheImpl) {
+        this.clientConfig = clientConfig;
+    }
+
+    private async isEnabled() {
+        if (!this.clientConfig) {
+            return true;
+        }
+
+        const value = await this.clientConfig.getOrDefault<unknown>("cache.enabled", false);
+        if (typeof value === "boolean") {
+            return value;
+        }
+        if (typeof value === "string") {
+            const normalized = value.trim().toLowerCase();
+            if (normalized === "true") return true;
+            if (normalized === "false") return false;
+        }
+        if (typeof value === "number") {
+            return value !== 0;
+        }
+        return Boolean(value);
+    }
 
     async get(key: string): Promise<any | null> {
+        if (!(await this.isEnabled())) {
+            return null;
+        }
         return this.data.get(key) ?? null;
     }
 
     async set(key: string, value: any, _save?: boolean): Promise<void> {
+        if (!(await this.isEnabled())) {
+            return;
+        }
         this.data.set(key, value);
     }
 
@@ -224,6 +254,9 @@ export class TestCacheImpl implements CacheImpl {
     }
 
     async getOrSet<T>(key: string, factory: () => Promise<T>): Promise<T> {
+        if (!(await this.isEnabled())) {
+            return factory();
+        }
         const cached = await this.get(key);
         if (cached !== null) return cached;
         const value = await factory();
@@ -232,15 +265,24 @@ export class TestCacheImpl implements CacheImpl {
     }
 
     async getOrDefault<T>(key: string, defaultValue: T): Promise<T> {
+        if (!(await this.isEnabled())) {
+            return defaultValue;
+        }
         const cached = await this.get(key);
         return cached !== null ? cached : defaultValue;
     }
 
     async getBySuffix(_suffix: string): Promise<any[]> {
+        if (!(await this.isEnabled())) {
+            return [];
+        }
         return [];
     }
 
     async all(): Promise<Map<string, any>> {
+        if (!(await this.isEnabled())) {
+            return new Map<string, any>();
+        }
         return new Map(this.data);
     }
 
@@ -279,9 +321,9 @@ export async function setupTestApp(
     const db = mockDB.db;
     const sqlite = mockDB.sqlite;
     const env = createMockEnv(envOverrides);
-    const cache = new TestCacheImpl();
     const serverConfig = new TestCacheImpl();
     const clientConfig = new TestCacheImpl();
+    const cache = new TestCacheImpl(clientConfig);
 
     const app = new Hono<{ Bindings: Env; Variables: Variables }>();
     app.use('*', timing({ totalDescription: '' }));
@@ -304,7 +346,7 @@ export async function setupTestApp(
             };
 
             c.set('db', db as any);
-            c.set('cache', new ConditionalCacheImpl(cache, clientConfig) as unknown as CacheImpl);
+            c.set('cache', cache);
             c.set('serverConfig', serverConfig);
             c.set('clientConfig', clientConfig);
             c.set('jwt', jwt);


### PR DESCRIPTION
## Summary
- move the public cache toggle into CacheImpl itself instead of relying on an outer wrapper
- ensure only the public `cache` store is gated by `cache.enabled`, while config stores remain readable to avoid recursion
- keep the existing cache setting semantics and add a regression test covering the non-recursive config path

## Testing
- cd server && bun run check
- cd server && bun test ./src/utils/__tests__/cache.test.ts ./src/services/__tests__/feed.test.ts ./src/services/__tests__/moments.test.ts