### PR TITLE
fix: restore scrolling after navigation

### DIFF
--- a/client/src/components/site-header/primitives/__tests__/menu.test.tsx
+++ b/client/src/components/site-header/primitives/__tests__/menu.test.tsx
@@ -59,8 +59,8 @@ describe("Menu", () => {
     });
   });
 
-  it("restores body scroll after a route change unmount path", async () => {
-    const { getByRole, rerender } = render(<Menu />);
+  it("restores body scroll when the menu unmounts during navigation", async () => {
+    const { getByRole, unmount } = render(<Menu />);
 
     fireEvent.click(getByRole("button"));
 
@@ -69,10 +69,8 @@ describe("Menu", () => {
     });
 
     location = "/timeline";
-    rerender(<Menu />);
+    unmount();
 
-    await waitFor(() => {
-      expect(document.body.style.overflow).toBe("");
-    });
+    expect(document.body.style.overflow).toBe("");
   });
 });

--- a/client/src/components/site-header/primitives/__tests__/menu.test.tsx
+++ b/client/src/components/site-header/primitives/__tests__/menu.test.tsx
@@ -1,13 +1,11 @@
 import "../../../../test/setup";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Menu } from "../menu";
 
-let location = "/";
-
 vi.mock("wouter", () => ({
-  useLocation: () => [location, vi.fn()],
+  useLocation: () => ["/", vi.fn()],
 }));
 
 vi.mock("reactjs-popup", () => ({
@@ -39,7 +37,11 @@ vi.mock("../nav-bar", () => ({
 
 describe("Menu", () => {
   beforeEach(() => {
-    location = "/";
+    document.body.style.overflow = "";
+  });
+
+  afterEach(() => {
+    cleanup();
     document.body.style.overflow = "";
   });
 
@@ -68,7 +70,6 @@ describe("Menu", () => {
       expect(document.body.style.overflow).toBe("hidden");
     });
 
-    location = "/timeline";
     unmount();
 
     expect(document.body.style.overflow).toBe("");

--- a/client/src/components/site-header/primitives/__tests__/menu.test.tsx
+++ b/client/src/components/site-header/primitives/__tests__/menu.test.tsx
@@ -1,0 +1,78 @@
+import "../../../../test/setup";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Menu } from "../menu";
+
+let location = "/";
+
+vi.mock("wouter", () => ({
+  useLocation: () => [location, vi.fn()],
+}));
+
+vi.mock("reactjs-popup", () => ({
+  default: ({
+    trigger,
+    open,
+    children,
+  }: {
+    trigger: ReactNode;
+    open?: boolean;
+    children: ReactNode;
+  }) => (
+    <>
+      {trigger}
+      {open ? children : null}
+    </>
+  ),
+}));
+
+vi.mock("../action-buttons", () => ({
+  LanguageSwitch: () => <div>language-switch</div>,
+  SearchButton: ({ onClose }: { onClose?: () => void }) => <button onClick={onClose}>search</button>,
+  UserAvatar: () => <div>user-avatar</div>,
+}));
+
+vi.mock("../nav-bar", () => ({
+  NavBar: ({ onClick }: { onClick?: () => void }) => <button onClick={onClick}>navigate</button>,
+}));
+
+describe("Menu", () => {
+  beforeEach(() => {
+    location = "/";
+    document.body.style.overflow = "";
+  });
+
+  it("restores body scroll when the menu closes", async () => {
+    const { getByRole } = render(<Menu />);
+
+    fireEvent.click(getByRole("button"));
+
+    await waitFor(() => {
+      expect(document.body.style.overflow).toBe("hidden");
+    });
+
+    fireEvent.click(getByRole("button", { name: "navigate" }));
+
+    await waitFor(() => {
+      expect(document.body.style.overflow).toBe("");
+    });
+  });
+
+  it("restores body scroll after a route change unmount path", async () => {
+    const { getByRole, rerender } = render(<Menu />);
+
+    fireEvent.click(getByRole("button"));
+
+    await waitFor(() => {
+      expect(document.body.style.overflow).toBe("hidden");
+    });
+
+    location = "/timeline";
+    rerender(<Menu />);
+
+    await waitFor(() => {
+      expect(document.body.style.overflow).toBe("");
+    });
+  });
+});

--- a/client/src/components/site-header/primitives/menu.tsx
+++ b/client/src/components/site-header/primitives/menu.tsx
@@ -1,14 +1,38 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Popup from "reactjs-popup";
+import { useLocation } from "wouter";
 import type { Profile } from "../../../state/profile";
 import { LanguageSwitch, SearchButton, UserAvatar } from "./action-buttons";
 import { NavBar } from "./nav-bar";
 
 export function Menu({ profile }: { profile?: Profile | null }) {
   const [isOpen, setOpen] = useState(false);
+  const [location] = useLocation();
+  const previousOverflowRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      if (previousOverflowRef.current !== null) {
+        document.body.style.overflow = previousOverflowRef.current;
+        previousOverflowRef.current = null;
+      }
+      return;
+    }
+
+    previousOverflowRef.current = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflowRef.current ?? "";
+      previousOverflowRef.current = null;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [location]);
 
   function onClose() {
-    document.body.style.overflow = "auto";
     setOpen(false);
   }
 
@@ -26,7 +50,6 @@ export function Menu({ profile }: { profile?: Profile | null }) {
         position="bottom right"
         open={isOpen}
         nested
-        onOpen={() => (document.body.style.overflow = "hidden")}
         onClose={onClose}
         closeOnDocumentClick
         closeOnEscape


### PR DESCRIPTION
## Summary
- move mobile menu scroll locking into a controlled effect
- restore body scrolling when the menu closes, the route changes, or the component unmounts
- add a regression test for navigation while the mobile menu is open

## Testing
- cd client && bun run check
- cd client && bun run test src/components/site-header/primitives/__tests__/menu.test.tsx