### PR TITLE
fix: stream storage blobs when no public host is configured

### DIFF
--- a/cli/src/tasks/deploy-cf.ts
+++ b/cli/src/tasks/deploy-cf.ts
@@ -147,7 +147,7 @@ export async function runCloudflareDeploy(target: "all" | "server" | "client" = 
   const taskQueueName = env("TASK_QUEUE_NAME", env("AI_SUMMARY_QUEUE_NAME", `${workerName}-tasks`)) ?? `${workerName}-tasks`;
   const r2BucketName = env("R2_BUCKET_NAME", "");
   const s3Endpoint = env("S3_ENDPOINT", "");
-  const s3AccessHost = env("S3_ACCESS_HOST", s3Endpoint);
+  const s3AccessHost = env("S3_ACCESS_HOST", "");
   const s3Bucket = env("S3_BUCKET", "");
   const s3CacheFolder = renv("S3_CACHE_FOLDER", "cache/");
   const s3Folder = renv("S3_FOLDER", "images/");
@@ -167,12 +167,11 @@ export async function runCloudflareDeploy(target: "all" | "server" | "client" = 
   let finalS3Bucket = s3Bucket;
   let finalS3AccessHost = s3AccessHost;
 
-  if (!finalS3Endpoint || !finalS3Bucket || !finalS3AccessHost) {
+  if (!finalS3Endpoint || !finalS3Bucket) {
     const r2Info = await resolveR2BucketInfo(r2BucketName || "");
     if (r2Info) {
       finalS3Endpoint ||= r2Info.endpoint;
       finalS3Bucket ||= r2Info.name;
-      finalS3AccessHost ||= r2Info.accessHost;
     }
   }
 

--- a/cli/src/tasks/setup-dev.ts
+++ b/cli/src/tasks/setup-dev.ts
@@ -24,7 +24,7 @@ export async function runSetupDev() {
     "JWT_SECRET",
   ];
   const storageRequiredVars = env.R2_BUCKET_NAME
-    ? ["S3_ACCESS_HOST"]
+    ? []
     : ["S3_ENDPOINT", "S3_BUCKET", "S3_ACCESS_KEY_ID", "S3_SECRET_ACCESS_KEY"];
   const requiredVars = [...baseRequiredVars, ...storageRequiredVars];
 
@@ -55,7 +55,7 @@ S3_FOLDER = "${env.S3_FOLDER || "images/"}"
 S3_CACHE_FOLDER = "${env.S3_CACHE_FOLDER || "cache/"}"
 S3_REGION = "${env.S3_REGION || "auto"}"
 S3_ENDPOINT = "${env.S3_ENDPOINT}"
-S3_ACCESS_HOST = "${env.S3_ACCESS_HOST || env.S3_ENDPOINT}"
+S3_ACCESS_HOST = "${env.S3_ACCESS_HOST || ""}"
 S3_BUCKET = "${env.S3_BUCKET}"
 S3_FORCE_PATH_STYLE = "${env.S3_FORCE_PATH_STYLE || "false"}"
 WEBHOOK_URL = "${env.WEBHOOK_URL || ""}"

--- a/server/src/core/register-routes.ts
+++ b/server/src/core/register-routes.ts
@@ -7,7 +7,7 @@ import { FeedService, SearchService, WordPressService } from "../services/feed";
 import { FriendService } from "../services/friends";
 import { MomentsService } from "../services/moments";
 import { RSSService } from "../services/rss";
-import { StorageService } from "../services/storage";
+import { BlobService, StorageService } from "../services/storage";
 import { TagService } from "../services/tag";
 import { UserService } from "../services/user";
 
@@ -20,6 +20,7 @@ export function registerRoutes(app: RinApp) {
   app.route("/tag", TagService());
   app.route("/comment", CommentService());
   app.route("/storage", StorageService());
+  app.route("/blob", BlobService());
   app.route("/friend", FriendService());
   app.route("/moments", MomentsService());
   app.route("/user", UserService());

--- a/server/src/services/__tests__/config.test.ts
+++ b/server/src/services/__tests__/config.test.ts
@@ -169,6 +169,38 @@ describe("ConfigService", () => {
                 ),
             ).toBe(true);
         });
+
+        it("should treat R2 storage without S3_ACCESS_HOST as configured", async () => {
+            env.R2_BUCKET = {
+                get: async () => null,
+                put: async () => null,
+                head: async () => null,
+                createMultipartUpload: () => {
+                    throw new Error("not implemented");
+                },
+                resumeMultipartUpload: () => {
+                    throw new Error("not implemented");
+                },
+                delete: async () => {},
+                list: async () => ({ objects: [], truncated: false, delimitedPrefixes: [] }),
+            } as unknown as R2Bucket;
+            env.S3_ACCESS_HOST = "" as any;
+
+            const res = await app.request("/health", {
+                method: "GET",
+                headers: {
+                    Authorization: "Bearer mock_token_1",
+                },
+            });
+
+            expect(res.status).toBe(200);
+            const data = await res.json() as {
+                items: Array<{ id: string; status: string }>;
+            };
+            expect(
+                data.items.some((item) => item.id === "storage" && item.status === "success"),
+            ).toBe(true);
+        });
     });
 
     describe("GET /queue-status - Queue status", () => {

--- a/server/src/services/__tests__/favicon.test.ts
+++ b/server/src/services/__tests__/favicon.test.ts
@@ -197,6 +197,68 @@ describe('FaviconService', () => {
                 globalThis.fetch = originalFetch;
             }
         });
+
+        it('should return favicon through R2 API when S3_ACCESS_HOST is missing', async () => {
+            const r2Env = createMockEnv({
+                S3_ACCESS_HOST: '' as any,
+                S3_ENDPOINT: '' as any,
+                S3_BUCKET: '' as any,
+                S3_ACCESS_KEY_ID: '',
+                S3_SECRET_ACCESS_KEY: '',
+                R2_BUCKET: {
+                    get: async (key: string) => {
+                        if (key !== 'images/favicon.webp') {
+                            return null;
+                        }
+
+                        return {
+                            key,
+                            size: 4,
+                            etag: 'etag',
+                            httpEtag: 'etag',
+                            uploaded: new Date('2025-01-01T00:00:00Z'),
+                            storageClass: 'Standard',
+                            checksums: {} as R2Checksums,
+                            httpMetadata: { contentType: 'image/webp' },
+                            writeHttpMetadata(headers: Headers) {
+                                headers.set('Content-Type', 'image/webp');
+                            },
+                            body: new Blob(['test']).stream(),
+                            bodyUsed: false,
+                            arrayBuffer: async () => new TextEncoder().encode('test').buffer,
+                            text: async () => 'test',
+                            json: async () => ({ value: 'test' }),
+                            blob: async () => new Blob(['test']),
+                            bytes: async () => new Uint8Array(new TextEncoder().encode('test')),
+                        } as unknown as R2ObjectBody;
+                    },
+                } as R2Bucket,
+            });
+
+            const r2App = new Hono<{ Bindings: Env; Variables: Variables }>();
+            r2App.use(createMiddleware<{ Bindings: Env; Variables: Variables }>(async (c, next) => {
+                c.set('db', db);
+                c.set('cache', new TestCacheImpl());
+                c.set('serverConfig', new TestCacheImpl());
+                c.set('clientConfig', new TestCacheImpl());
+                c.set('jwt', {
+                    sign: async (payload: any) => `mock_token_${payload.id}`,
+                    verify: async (token: string) => token.startsWith('mock_token_') ? { id: 1 } : null,
+                } as JWTUtils);
+                c.set('oauth2', undefined);
+                c.set('env', r2Env);
+                c.set('uid', 1);
+                c.set('admin', true);
+                await next();
+            }));
+            r2App.route('/', FaviconService());
+
+            const res = await r2App.request('/', { method: 'GET' }, r2Env);
+
+            expect(res.status).toBe(200);
+            expect(res.headers.get('content-type')).toBe('image/webp');
+            expect(await res.text()).toBe('test');
+        });
     });
 
     describe('GET /original - Get original favicon', () => {

--- a/server/src/services/__tests__/rss.test.ts
+++ b/server/src/services/__tests__/rss.test.ts
@@ -126,6 +126,53 @@ describe('RSSService', () => {
             const itemCount = (text.match(/<item>/g) || []).length;
             expect(itemCount).toBeLessThanOrEqual(20);
         });
+
+        it('should serve cached rss.xml through R2 without S3_ACCESS_HOST', async () => {
+            const cachedEnv = createMockEnv({
+                S3_ACCESS_HOST: '' as any,
+                S3_ENDPOINT: '' as any,
+                S3_BUCKET: '' as any,
+                S3_ACCESS_KEY_ID: '',
+                S3_SECRET_ACCESS_KEY: '',
+                R2_BUCKET: {
+                    get: async (key: string) => {
+                        if (key !== 'cache/rss.xml') {
+                            return null;
+                        }
+
+                        return {
+                            key,
+                            size: 18,
+                            etag: 'etag',
+                            httpEtag: 'etag',
+                            uploaded: new Date('2025-01-01T00:00:00Z'),
+                            storageClass: 'Standard',
+                            checksums: {} as R2Checksums,
+                            httpMetadata: { contentType: 'application/rss+xml; charset=UTF-8' },
+                            writeHttpMetadata(headers: Headers) {
+                                headers.set('Content-Type', 'application/rss+xml; charset=UTF-8');
+                            },
+                            body: new Blob(['<rss>cached</rss>']).stream(),
+                            bodyUsed: false,
+                            arrayBuffer: async () => new TextEncoder().encode('<rss>cached</rss>').buffer,
+                            text: async () => '<rss>cached</rss>',
+                            json: async () => ({ value: 'cached' }),
+                            blob: async () => new Blob(['<rss>cached</rss>']),
+                            bytes: async () => new Uint8Array(new TextEncoder().encode('<rss>cached</rss>')),
+                        } as unknown as R2ObjectBody;
+                    },
+                    head: async () => null,
+                } as unknown as R2Bucket,
+            });
+
+            const ctx = await setupTestApp(RSSService, cachedEnv);
+            const res = await ctx.app.request('/rss.xml', { method: 'GET' }, cachedEnv);
+
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe('<rss>cached</rss>');
+
+            cleanupTestDB(ctx.sqlite);
+        });
     });
 });
 

--- a/server/src/services/__tests__/storage.test.ts
+++ b/server/src/services/__tests__/storage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { StorageService } from '../storage';
+import { BlobService, StorageService } from '../storage';
 import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { Variables, JWTUtils, CacheImpl } from "../../core/hono-types";
@@ -91,6 +91,7 @@ describe('StorageService', () => {
 
         // Mount service
         app.route('/', StorageService());
+        app.route('/blob', BlobService());
 
         // Create test user
         await createTestUser();
@@ -123,6 +124,7 @@ describe('StorageService', () => {
             await next();
         }));
         serviceApp.route('/', StorageService());
+        serviceApp.route('/blob', BlobService());
         return serviceApp;
     }
 
@@ -164,7 +166,7 @@ describe('StorageService', () => {
                             writeHttpMetadata: () => {},
                         } as unknown as R2Object;
                     },
-                } as R2Bucket,
+                } as unknown as R2Bucket,
                 S3_ACCESS_HOST: 'https://images.example.com' as any,
                 S3_ENDPOINT: '' as any,
                 S3_BUCKET: '' as any,
@@ -188,6 +190,49 @@ describe('StorageService', () => {
             expect(putCalls[0]?.type).toBe('text/plain;charset=utf-8');
             const payload = await res.json() as { url: string };
             expect(payload.url).toMatch(/^https:\/\/images\.example\.com\/images\/[a-f0-9]+\.txt$/);
+        });
+
+        it('should return a /blob URL when R2 is configured without S3_ACCESS_HOST', async () => {
+            const putCalls: string[] = [];
+            const r2Env = createMockEnv({
+                R2_BUCKET: {
+                    put: async (key: string) => {
+                        putCalls.push(key);
+                        return {
+                            key,
+                            version: '1',
+                            size: 4,
+                            etag: 'etag',
+                            httpEtag: 'etag',
+                            uploaded: new Date(),
+                            storageClass: 'Standard',
+                            checksums: {} as R2Checksums,
+                            writeHttpMetadata: () => {},
+                        } as unknown as R2Object;
+                    },
+                } as unknown as R2Bucket,
+                S3_ACCESS_HOST: '' as any,
+                S3_ENDPOINT: '' as any,
+                S3_BUCKET: '' as any,
+                S3_ACCESS_KEY_ID: '',
+                S3_SECRET_ACCESS_KEY: '',
+            });
+
+            const r2App = createAppWithEnv(r2Env, 1);
+            const formData = new FormData();
+            formData.append('key', 'test.txt');
+            formData.append('file', new File(['test'], 'test.txt', { type: 'text/plain' }));
+
+            const res = await r2App.request('/', {
+                method: 'POST',
+                body: formData,
+            }, r2Env);
+
+            expect(res.status).toBe(200);
+            expect(putCalls).toHaveLength(1);
+
+            const payload = await res.json() as { url: string };
+            expect(payload.url).toMatch(/^http:\/\/localhost\/blob\/images\/[a-f0-9]+\.txt$/);
         });
 
         it('should return 500 when S3_ENDPOINT is not defined without R2 binding', async () => {
@@ -226,6 +271,53 @@ describe('StorageService', () => {
 
             expect(res.status).toBe(500);
             expect(await res.text()).toBe('S3_ACCESS_KEY_ID is not defined');
+        });
+    });
+
+    describe('GET /blob/* - Stream file', () => {
+        it('should stream an R2 object through the blob route', async () => {
+            const r2Env = createMockEnv({
+                R2_BUCKET: {
+                    get: async (key: string) => {
+                        if (key !== 'images/test.txt') {
+                            return null;
+                        }
+
+                        return {
+                            key,
+                            size: 4,
+                            etag: 'etag',
+                            httpEtag: 'etag',
+                            uploaded: new Date('2025-01-01T00:00:00Z'),
+                            storageClass: 'Standard',
+                            checksums: {} as R2Checksums,
+                            httpMetadata: { contentType: 'text/plain' },
+                            writeHttpMetadata(headers: Headers) {
+                                headers.set('Content-Type', 'text/plain');
+                            },
+                            body: new Blob(['test']).stream(),
+                            bodyUsed: false,
+                            arrayBuffer: async () => new TextEncoder().encode('test').buffer,
+                            text: async () => 'test',
+                            json: async () => ({ value: 'test' }),
+                            blob: async () => new Blob(['test']),
+                            bytes: async () => new Uint8Array(new TextEncoder().encode('test')),
+                        } as unknown as R2ObjectBody;
+                    },
+                } as unknown as R2Bucket,
+                S3_ACCESS_HOST: '' as any,
+                S3_ENDPOINT: '' as any,
+                S3_BUCKET: '' as any,
+                S3_ACCESS_KEY_ID: '',
+                S3_SECRET_ACCESS_KEY: '',
+            });
+
+            const r2App = createAppWithEnv(r2Env, 1);
+            const res = await r2App.request('/blob/images/test.txt', { method: 'GET' }, r2Env);
+
+            expect(res.status).toBe(200);
+            expect(res.headers.get('content-type')).toBe('text/plain');
+            expect(await res.text()).toBe('test');
         });
     });
 });

--- a/server/src/services/config-health.ts
+++ b/server/src/services/config-health.ts
@@ -178,7 +178,7 @@ export async function buildHealthCheckResponse(
 
   const usesR2Binding = Boolean(env.R2_BUCKET);
   const requiredStorageKeys = usesR2Binding
-    ? ([["S3_ACCESS_HOST", env.S3_ACCESS_HOST]] as const)
+    ? ([] as const)
     : ([
         ["S3_ENDPOINT", env.S3_ENDPOINT],
         ["S3_BUCKET", env.S3_BUCKET],
@@ -193,15 +193,11 @@ export async function buildHealthCheckResponse(
       createItem({
         id: "storage",
         title: text("health.items.storage.title"),
-        status: hasAccessHost ? "success" : "warning",
+        status: "success",
         configured: true,
         impact: text("health.items.storage.ready.impact"),
-        summary: hasAccessHost
-          ? text("health.items.storage.ready.summary")
-          : text("health.items.storage.ready.summary_missing_access_host"),
-        suggestion: hasAccessHost
-          ? text("health.items.common.no_action")
-          : text("health.items.storage.ready.suggestion_missing_access_host"),
+        summary: text("health.items.storage.ready.summary"),
+        suggestion: text("health.items.common.no_action"),
       }),
     );
   } else {

--- a/server/src/services/favicon.ts
+++ b/server/src/services/favicon.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { AppContext } from "../core/hono-types";
 import { profileAsync } from "../core/server-timing";
 import { path_join } from "../utils/path";
-import { createS3Client, putObject } from "../utils/s3";
+import { getStorageObject, getStoragePublicUrl, putStorageObjectAtKey } from "../utils/storage";
 
 // @see https://developers.cloudflare.com/images/url-format#supported-formats-and-limitations
 export const FAVICON_ALLOWED_TYPES: { [key: string]: string } = {
@@ -18,7 +18,6 @@ export function getFaviconKey(env: Env) {
 
 async function buildFaviconFromSource(c: AppContext, sourceUrl: string, faviconKey: string) {
     const env = c.get('env');
-    const s3 = createS3Client(env);
     const imageRequest = new Request(sourceUrl, {
         headers: c.req.raw.headers,
     });
@@ -40,8 +39,7 @@ async function buildFaviconFromSource(c: AppContext, sourceUrl: string, faviconK
     }
 
     const arrayBuffer = await response.arrayBuffer();
-    await putObject(
-        s3,
+    await putStorageObjectAtKey(
         env,
         faviconKey,
         new Uint8Array(arrayBuffer),
@@ -64,17 +62,16 @@ export function FaviconService(): Hono {
     app.get("/", async (c: AppContext) => {
         const env = c.get('env');
         const clientConfig = c.get('clientConfig');
-        const accessHost = env.S3_ACCESS_HOST || env.S3_ENDPOINT;
         const faviconKey = getFaviconKey(env);
         
         try {
-            const response = await profileAsync(c, 'favicon_fetch', () => fetch(new Request(`${accessHost}/${faviconKey}`)));
+            const response = await profileAsync(c, 'favicon_fetch', () => getStorageObject(env, faviconKey));
 
-            if (!response.ok) {
+            if (!response) {
                 const avatar = await profileAsync(c, 'favicon_avatar', () => clientConfig.get("site.avatar")) as string | undefined;
                 if (!avatar) {
-                    c.status(response.status as 200 | 400 | 401 | 403 | 404 | 500);
-                    return c.text(await response.text());
+                    c.status(404);
+                    return c.text("Favicon not found");
                 }
 
                 const avatarUrl = new URL(avatar, c.req.url).toString();
@@ -105,15 +102,13 @@ export function FaviconService(): Hono {
     // GET /favicon/original
     app.get("/original", async (c: AppContext) => {
         const env = c.get('env');
-        const accessHost = env.S3_ACCESS_HOST || env.S3_ENDPOINT;
         
         try {
-            let originFaviconKey: string | null = null;
             for (const [mimeType, ext] of Object.entries(FAVICON_ALLOWED_TYPES)) {
-                originFaviconKey = path_join(env.S3_FOLDER || "", `originFavicon${ext}`);
-                const response = await profileAsync(c, 'favicon_original_fetch', () => fetch(new Request(`${accessHost}/${originFaviconKey}`)));
+                const originFaviconKey = path_join(env.S3_FOLDER || "", `originFavicon${ext}`);
+                const response = await profileAsync(c, 'favicon_original_fetch', () => getStorageObject(env, originFaviconKey));
 
-                if (response.ok) {
+                if (response) {
                     c.header("Content-Type", mimeType);
                     c.header("Cache-Control", "public, max-age=31536000");
                     return c.body(await profileAsync(c, 'favicon_original_body', () => response.arrayBuffer()));
@@ -135,9 +130,6 @@ export function FaviconService(): Hono {
     app.post("/", async (c: AppContext) => {
         const env = c.get('env');
         const admin = c.get('admin');
-        
-        const s3 = createS3Client(env);
-        const accessHost = env.S3_ACCESS_HOST || env.S3_ENDPOINT;
         const faviconKey = getFaviconKey(env);
         
         try {
@@ -170,14 +162,14 @@ export function FaviconService(): Hono {
                 `originFavicon${FAVICON_ALLOWED_TYPES[file.type]}`,
             );
 
-            await profileAsync(c, 'favicon_origin_put', () => putObject(
-                s3,
+            await profileAsync(c, 'favicon_origin_put', () => putStorageObjectAtKey(
                 env,
                 originFaviconKey,
                 file
             ));
 
-            const imageRequest = new Request(`${accessHost}/${originFaviconKey}`, {
+            const originFaviconUrl = getStoragePublicUrl(env, originFaviconKey, new URL(c.req.url).origin);
+            const imageRequest = new Request(originFaviconUrl, {
                 headers: c.req.raw.headers,
             });
 
@@ -200,14 +192,13 @@ export function FaviconService(): Hono {
 
             const arrayBuffer = await profileAsync(c, 'favicon_transform_body', () => response.arrayBuffer());
 
-            await profileAsync(c, 'favicon_put', () => putObject(
-                s3,
+            await profileAsync(c, 'favicon_put', () => putStorageObjectAtKey(
                 env,
                 faviconKey,
                 new Uint8Array(arrayBuffer)
             ));
 
-            return c.json({ url: `${accessHost}/${faviconKey}` });
+            return c.json({ url: getStoragePublicUrl(env, faviconKey, new URL(c.req.url).origin) });
         } catch (error) {
             if (error instanceof Error) {
                 c.status(500);

--- a/server/src/services/rss.ts
+++ b/server/src/services/rss.ts
@@ -5,7 +5,7 @@ import { profileAsync } from "../core/server-timing";
 import { feeds, users } from "../db/schema";
 import { extractImage } from "../utils/image";
 import { path_join } from "../utils/path";
-import { createS3Client, putObject } from "../utils/s3";
+import { getStorageObject, getStoragePublicUrl, headStorageObject, putStorageObjectAtKey } from "../utils/storage";
 import { FAVICON_ALLOWED_TYPES, getFaviconKey } from "./favicon";
 import type { DB } from "../core/hono-types";
 
@@ -72,10 +72,7 @@ async function handleFeed(c: AppContext, fileName: string) {
     const env = c.get('env');
     const db = c.get('db');
 
-    const endpoint = env.S3_ENDPOINT;
-    const accessHost = env.S3_ACCESS_HOST || endpoint;
     const folder = env.S3_CACHE_FOLDER || 'cache/';
-    const host = `${(accessHost.startsWith("http://") || accessHost.startsWith("https://") ? '' : 'https://')}${accessHost}`;
 
     // Map file extensions to proper MIME types
     const contentTypeMap: Record<string, string> = {
@@ -88,40 +85,20 @@ async function handleFeed(c: AppContext, fileName: string) {
 
     // Try to fetch from S3 first (if configured)
     const key = path_join(folder, fileName);
-    const cleanHost = host.endsWith('/') ? host.slice(0, -1) : host;
-    const url = `${cleanHost}/${key}`;
     
-    // Check if S3 is properly configured (not default/placeholder values)
-    const s3Configured = host && 
-                       !host.includes('your-') && 
-                       !host.includes('undefined') &&
-                       env.S3_BUCKET && 
-                       !env.S3_BUCKET.includes('your-bucket');
-    
-    if (s3Configured) {
-        try {
-            console.log(`[RSS] Fetching from S3: ${url}`);
-            const response = await profileAsync(c, 'rss_s3_fetch', () => fetch(url, { 
-                cf: { cacheTtl: 60 } 
-            }));
-            
-            if (response.ok) {
-                console.log(`[RSS] S3 hit!`);
-                const text = await profileAsync(c, 'rss_s3_body', () => response.text());
-                return c.text(text, 200, {
-                    'Content-Type': contentType,
-                    'Cache-Control': 'public, max-age=3600',
-                });
-            }
-            
-            if (response.status !== 404) {
-                console.log(`[RSS] S3 error: ${response.status}, falling back to generation`);
-            }
-        } catch (e: any) {
-            console.log(`[RSS] S3 fetch failed: ${e.message}, falling back to generation`);
+    try {
+        const response = await profileAsync(c, 'rss_s3_fetch', () => getStorageObject(env, key));
+
+        if (response) {
+            console.log(`[RSS] Storage hit for ${key}`);
+            const text = await profileAsync(c, 'rss_s3_body', () => response.text());
+            return c.text(text, 200, {
+                'Content-Type': contentType,
+                'Cache-Control': 'public, max-age=3600',
+            });
         }
-    } else {
-        console.log(`[RSS] S3 not configured, generating feed in real-time`);
+    } catch (e: any) {
+        console.log(`[RSS] Storage fetch failed: ${e.message}, falling back to generation`);
     }
     
     // Generate feed in real-time (fallback or primary mode)
@@ -163,8 +140,8 @@ async function generateFeed(env: Env, db: DB, frontendUrl: string, c?: AppContex
     } else {
         await initRSSModules();
     }
-    const accessHost = env.S3_ACCESS_HOST || env.S3_ENDPOINT;
     const faviconKey = getFaviconKey(env);
+    const publicBaseUrl = frontendUrl || undefined;
 
     let feedConfig: any = {
         title: env.RSS_TITLE,
@@ -191,32 +168,30 @@ async function generateFeed(env: Env, db: DB, frontendUrl: string, c?: AppContex
         }
     }
 
-    // Try to get favicon from S3
-    if (accessHost && !accessHost.includes('your-') && !accessHost.includes('undefined')) {
-        for (const [_mimeType, ext] of Object.entries(FAVICON_ALLOWED_TYPES)) {
-            const originFaviconKey = path_join(env.S3_FOLDER || "", `originFavicon${ext}`);
-            try {
-                const response = c
-                    ? await profileAsync(c, 'rss_origin_favicon_fetch', () => fetch(new Request(`${accessHost}/${originFaviconKey}`)))
-                    : await fetch(new Request(`${accessHost}/${originFaviconKey}`));
-                if (response.ok) {
-                    feedConfig.image = `${accessHost}/${originFaviconKey}`;
-                    break;
-                }
-            } catch (error) {
-                continue;
-            }
-        }
-
+    // Try to discover stored favicon assets.
+    for (const [_mimeType, ext] of Object.entries(FAVICON_ALLOWED_TYPES)) {
+        const originFaviconKey = path_join(env.S3_FOLDER || "", `originFavicon${ext}`);
         try {
             const response = c
-                ? await profileAsync(c, 'rss_favicon_fetch', () => fetch(new Request(`${accessHost}/${faviconKey}`)))
-                : await fetch(new Request(`${accessHost}/${faviconKey}`));
-            if (response.ok) {
-                feedConfig.favicon = `${accessHost}/${faviconKey}`;
+                ? await profileAsync(c, 'rss_origin_favicon_fetch', () => headStorageObject(env, originFaviconKey))
+                : await headStorageObject(env, originFaviconKey);
+            if (response) {
+                feedConfig.image = getStoragePublicUrl(env, originFaviconKey, publicBaseUrl);
+                break;
             }
-        } catch (error) { }
+        } catch (error) {
+            continue;
+        }
     }
+
+    try {
+        const response = c
+            ? await profileAsync(c, 'rss_favicon_fetch', () => headStorageObject(env, faviconKey))
+            : await headStorageObject(env, faviconKey);
+        if (response) {
+            feedConfig.favicon = getStoragePublicUrl(env, faviconKey, publicBaseUrl);
+        }
+    } catch (error) { }
 
     const feed = new Feed(feedConfig);
 
@@ -287,13 +262,11 @@ export async function rssCrontab(env: Env, db: DB) {
     
     // Save to S3 (if configured)
     const folder = env.S3_CACHE_FOLDER || "cache/";
-    const s3 = createS3Client(env);
 
     async function save(name: string, data: string) {
         const hashkey = path_join(folder, name);
         try {
-            await putObject(
-                s3,
+            await putStorageObjectAtKey(
                 env,
                 hashkey,
                 data,

--- a/server/src/services/storage.ts
+++ b/server/src/services/storage.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { AppContext } from "../core/hono-types";
 import { profileAsync } from "../core/server-timing";
-import { putStorageObject } from "../utils/storage";
+import { getStorageObject, putStorageObject } from "../utils/storage";
 
 function buf2hex(buffer: ArrayBuffer) {
     return [...new Uint8Array(buffer)]
@@ -35,12 +35,43 @@ export function StorageService(): Hono {
         const hashkey = `${hash}.${suffix}`;
         
         try {
-            const result = await profileAsync(c, 'storage_put', () => putStorageObject(env, hashkey, file, file.type));
+            const result = await profileAsync(c, 'storage_put', () => putStorageObject(env, hashkey, file, file.type, new URL(c.req.url).origin));
             return c.json({ url: result.url });
         } catch (e: any) {
             console.error(e.message);
             const status = e.message?.includes('is not defined') ? 500 : 400;
             return c.text(e.message, status);
+        }
+    });
+
+    return app;
+}
+
+export function BlobService(): Hono {
+    const app = new Hono();
+
+    app.get("/*", async (c: AppContext) => {
+        const env = c.get("env");
+        const key = c.req.path.replace(/^\/blob\/?/, "");
+
+        if (!key) {
+            return c.text("Blob key is required", 400);
+        }
+
+        try {
+            const response = await profileAsync(c, "blob_fetch", () => getStorageObject(env, decodeURIComponent(key)));
+
+            if (!response) {
+                return c.text("Not found", 404);
+            }
+
+            return new Response(response.body, {
+                status: response.status,
+                headers: response.headers,
+            });
+        } catch (error) {
+            console.error("Blob fetch failed:", error);
+            return c.text("Blob fetch failed", 500);
         }
     });
 

--- a/server/src/utils/__tests__/cache.test.ts
+++ b/server/src/utils/__tests__/cache.test.ts
@@ -444,6 +444,47 @@ describe('CacheImpl - 存储模式配置测试', () => {
         
         expect(cache).toBeDefined();
     });
+
+    it('应该在 R2 绑定下通过存储 API 读取缓存文件', async () => {
+        mockEnv = createMockEnv('s3');
+        mockEnv.R2_BUCKET = {
+            get: async (key: string) => {
+                if (key !== 'cache/cache.json') {
+                    return null;
+                }
+
+                return {
+                    key,
+                    size: 17,
+                    etag: 'etag',
+                    httpEtag: 'etag',
+                    uploaded: new Date('2025-01-01T00:00:00Z'),
+                    storageClass: 'Standard',
+                    checksums: {} as R2Checksums,
+                    httpMetadata: { contentType: 'application/json' },
+                    writeHttpMetadata(headers: Headers) {
+                        headers.set('Content-Type', 'application/json');
+                    },
+                    body: new Blob(['{"key1":"value1"}']).stream(),
+                    bodyUsed: false,
+                    arrayBuffer: async () => new TextEncoder().encode('{"key1":"value1"}').buffer,
+                    text: async () => '{"key1":"value1"}',
+                    json: async () => ({ key1: 'value1' }),
+                    blob: async () => new Blob(['{"key1":"value1"}']),
+                    bytes: async () => new Uint8Array(new TextEncoder().encode('{"key1":"value1"}')),
+                } as unknown as R2ObjectBody;
+            },
+        } as unknown as R2Bucket;
+        mockEnv.S3_ACCESS_HOST = '' as any;
+        mockEnv.S3_ENDPOINT = '' as any;
+        mockEnv.S3_BUCKET = '' as any;
+        mockEnv.S3_ACCESS_KEY_ID = '';
+        mockEnv.S3_SECRET_ACCESS_KEY = '';
+
+        const cache = new CacheImpl(db as any, mockEnv, 'cache', 's3');
+
+        expect(await cache.get('key1')).toBe('value1');
+    });
 });
 
 describe('CacheImpl - 工厂函数测试', () => {

--- a/server/src/utils/cache.ts
+++ b/server/src/utils/cache.ts
@@ -2,6 +2,7 @@ import { eq, and, like } from "drizzle-orm";
 import type { DB } from "../core/hono-types";
 import { cache } from "../db/schema";
 import { path_join } from "./path";
+import { getStorageObject, putStorageObjectAtKey } from "./storage";
 
 // Cache Utils for storing data in memory and persisting to database (with optional S3 backup)
 
@@ -130,32 +131,18 @@ class DatabaseStorageProvider implements StorageProvider {
 
 // S3 存储提供者
 class S3StorageProvider implements StorageProvider {
-    private s3Instance: any = null;
-    private cacheUrl: string;
+    private cacheKey: string;
 
     constructor(private env: Env, private cacheMap: Map<string, any>, private type: string) {
-        const slash = this.env.S3_ACCESS_HOST.endsWith('/') ? '' : '/';
-        this.cacheUrl = this.env.S3_ACCESS_HOST + slash + path_join(this.env.S3_CACHE_FOLDER || 'cache', `${type}.json`);
-    }
-
-    private async getS3() {
-        if (!this.s3Instance) {
-            const { createS3Client } = await import('./s3');
-            this.s3Instance = createS3Client(this.env);
-        }
-        return this.s3Instance;
+        this.cacheKey = path_join(this.env.S3_CACHE_FOLDER || 'cache', `${type}.json`);
     }
 
     async load(): Promise<void> {
-        console.log('Cache load from S3', this.cacheUrl);
+        console.log('Cache load from storage', this.cacheKey);
         try {
-            const response = await fetch(new Request(this.cacheUrl));
-            if (!response.ok) {
-                if (response.status === 404) {
-                    console.log('Cache file not found in S3, starting with empty cache');
-                } else {
-                    console.error(`Cache load from S3 failed: HTTP ${response.status}`);
-                }
+            const response = await getStorageObject(this.env, this.cacheKey);
+            if (!response) {
+                console.log('Cache file not found in storage, starting with empty cache');
                 return;
             }
             const data = await response.json<any>();
@@ -170,23 +157,19 @@ class S3StorageProvider implements StorageProvider {
 
     async save(): Promise<void> {
         try {
-            const { putObject } = await import('./s3');
-            const s3 = await this.getS3();
-            const cacheKey = path_join(this.env.S3_CACHE_FOLDER, `${this.type}.json`);
-            await putObject(
-                s3,
+            await putStorageObjectAtKey(
                 this.env,
-                cacheKey,
+                this.cacheKey,
                 JSON.stringify(Object.fromEntries(this.cacheMap)),
                 'application/json'
             ).then(() => {
-                console.log('Cache saved to S3');
+                console.log('Cache saved to storage');
             }).catch((e: any) => {
-                console.error('Cache save to S3 failed');
+                console.error('Cache save to storage failed');
                 console.error(e.message);
             });
         } catch (e: any) {
-            console.error('Cache save to S3 failed');
+            console.error('Cache save to storage failed');
             console.error(e.message);
         }
     }

--- a/server/src/utils/s3.ts
+++ b/server/src/utils/s3.ts
@@ -50,3 +50,16 @@ export async function putObject(
     
     return response;
 }
+
+export function buildS3ObjectUrl(env: Env, key: string): string {
+    const endpoint = env.S3_ENDPOINT;
+    const bucket = env.S3_BUCKET;
+    const forcePathStyle = env.S3_FORCE_PATH_STYLE === 'true';
+
+    if (forcePathStyle) {
+        return path_join(endpoint, bucket, key);
+    }
+
+    const urlObj = new URL(endpoint);
+    return `${urlObj.protocol}//${bucket}.${urlObj.host}/${key}`;
+}

--- a/server/src/utils/storage.ts
+++ b/server/src/utils/storage.ts
@@ -1,5 +1,5 @@
 import { path_join } from "./path";
-import { createS3Client, putObject as putS3Object } from "./s3";
+import { buildS3ObjectUrl, createS3Client, putObject as putS3Object } from "./s3";
 
 type StorageTarget =
   | {
@@ -24,9 +24,6 @@ export function resolveStorageTarget(env: Env): StorageTarget {
   const publicBaseUrl = trimTrailingSlash(env.S3_ACCESS_HOST || env.S3_ENDPOINT || "");
 
   if (env.R2_BUCKET) {
-    if (!publicBaseUrl) {
-      throw new Error("S3_ACCESS_HOST is not defined");
-    }
     return {
       type: "r2",
       bucket: env.R2_BUCKET,
@@ -56,17 +53,127 @@ export function resolveStorageTarget(env: Env): StorageTarget {
   };
 }
 
+function encodeStorageKey(key: string) {
+  return key
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function buildBlobUrl(storageKey: string, baseUrl?: string) {
+  const encodedKey = encodeStorageKey(storageKey);
+  const path = `/blob/${encodedKey}`;
+
+  if (!baseUrl) {
+    return path;
+  }
+
+  return `${trimTrailingSlash(baseUrl)}${path}`;
+}
+
+function createStorageResponse(object: R2ObjectBody | R2Object, body?: BodyInit | null) {
+  const headers = new Headers();
+  object.writeHttpMetadata(headers);
+
+  if (object.httpEtag) {
+    headers.set("ETag", object.httpEtag);
+  }
+
+  if (!headers.has("Content-Length")) {
+    headers.set("Content-Length", String(object.size));
+  }
+
+  if (!headers.has("Last-Modified")) {
+    headers.set("Last-Modified", object.uploaded.toUTCString());
+  }
+
+  return new Response(body ?? null, {
+    status: 200,
+    headers,
+  });
+}
+
+export async function getStorageObject(env: Env, storageKey: string): Promise<Response | null> {
+  if (env.R2_BUCKET) {
+    const object = await env.R2_BUCKET.get(storageKey);
+    if (!object) {
+      return null;
+    }
+    return createStorageResponse(object, object.body);
+  }
+
+  const client = createS3Client(env);
+  const response = await client.fetch(buildS3ObjectUrl(env, storageKey), {
+    method: "GET",
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch storage object: ${response.status} ${response.statusText}`);
+  }
+
+  return response;
+}
+
+export async function headStorageObject(env: Env, storageKey: string): Promise<Response | null> {
+  if (env.R2_BUCKET) {
+    const object = await env.R2_BUCKET.head(storageKey);
+    if (!object) {
+      return null;
+    }
+    return createStorageResponse(object);
+  }
+
+  const client = createS3Client(env);
+  const response = await client.fetch(buildS3ObjectUrl(env, storageKey), {
+    method: "HEAD",
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to inspect storage object: ${response.status} ${response.statusText}`);
+  }
+
+  return response;
+}
+
+export function getStoragePublicUrl(env: Env, storageKey: string, baseUrl?: string) {
+  if (env.S3_ACCESS_HOST) {
+    return `${trimTrailingSlash(env.S3_ACCESS_HOST)}/${storageKey}`;
+  }
+
+  return buildBlobUrl(storageKey, baseUrl);
+}
+
 export async function putStorageObject(
   env: Env,
   key: string,
   body: Blob | ArrayBuffer | Uint8Array | string,
   contentType?: string,
+  baseUrl?: string,
 ) {
   const target = resolveStorageTarget(env);
   const storageKey = path_join(target.folder, key);
 
-  if (target.type === "r2") {
-    await target.bucket.put(storageKey, body, {
+  return putStorageObjectAtKey(env, storageKey, body, contentType, baseUrl);
+}
+
+export async function putStorageObjectAtKey(
+  env: Env,
+  storageKey: string,
+  body: Blob | ArrayBuffer | Uint8Array | string,
+  contentType?: string,
+  baseUrl?: string,
+) {
+  if (env.R2_BUCKET) {
+    await env.R2_BUCKET.put(storageKey, body, {
       httpMetadata: contentType ? { contentType } : undefined,
     });
   } else {
@@ -76,6 +183,6 @@ export async function putStorageObject(
 
   return {
     key: storageKey,
-    url: `${target.publicBaseUrl}/${storageKey}`,
+    url: getStoragePublicUrl(env, storageKey, baseUrl),
   };
 }


### PR DESCRIPTION
## Summary
- add a /blob service that streams objects from R2 or S3 when no S3_ACCESS_HOST is configured
- switch cache, RSS, and favicon reads to storage APIs instead of public-host fetches
- stop requiring or auto-filling S3_ACCESS_HOST for R2-backed setups in dev, deploy, and health checks

## Verification
- cd server && bun run test
- cd server && bun run check
- cd client && bun run test
- cd client && bun run check
- cd client && bun run build
- bun run check
- bun run format:check
