### PR TITLE
fix: fall back to app for non-asset dotted paths

### DIFF
--- a/server/src/runtime/__tests__/fetch-handler.test.ts
+++ b/server/src/runtime/__tests__/fetch-handler.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+const getAppFetch = mock();
+
+mock.module("../app-instance", () => ({
+  getApp: () => ({
+    fetch: getAppFetch,
+  }),
+}));
+
+describe("handleFetch", () => {
+  afterEach(() => {
+    getAppFetch.mockReset();
+  });
+
+  it("serves static assets directly when the asset exists", async () => {
+    getAppFetch.mockResolvedValue(new Response("app-body", { status: 200 }));
+
+    const { handleFetch } = await import("../fetch-handler");
+    const assetFetch = mock(async () => new Response("asset-body", { status: 200 }));
+
+    const response = await handleFetch(
+      new Request("http://localhost/assets/app.js"),
+      {
+        ASSETS: {
+          fetch: assetFetch,
+        },
+      } as unknown as Env,
+    );
+
+    expect(await response.text()).toBe("asset-body");
+    expect(assetFetch).toHaveBeenCalledTimes(1);
+    expect(getAppFetch).toHaveBeenCalledTimes(0);
+  });
+
+  it("falls back to the app when a dotted path is not a static asset", async () => {
+    getAppFetch.mockResolvedValue(new Response("blob-body", { status: 200 }));
+
+    const { handleFetch } = await import("../fetch-handler");
+    const assetFetch = mock(async () => new Response("asset-body", { status: 404 }));
+
+    const response = await handleFetch(
+      new Request("http://localhost/blob/images/test.txt"),
+      {
+        ASSETS: {
+          fetch: assetFetch,
+        },
+      } as unknown as Env,
+    );
+
+    expect(await response.text()).toBe("blob-body");
+    expect(getAppFetch).toHaveBeenCalledTimes(1);
+    expect(assetFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/runtime/__tests__/fetch-handler.test.ts
+++ b/server/src/runtime/__tests__/fetch-handler.test.ts
@@ -33,14 +33,14 @@ describe("handleFetch", () => {
     expect(getAppFetch).toHaveBeenCalledTimes(0);
   });
 
-  it("falls back to the app when a dotted path is not a static asset", async () => {
+  it("routes /api/blob requests to the app before static assets", async () => {
     getAppFetch.mockResolvedValue(new Response("blob-body", { status: 200 }));
 
     const { handleFetch } = await import("../fetch-handler");
     const assetFetch = mock(async () => new Response("asset-body", { status: 404 }));
 
     const response = await handleFetch(
-      new Request("http://localhost/blob/images/test.txt"),
+      new Request("http://localhost/api/blob/images/test.txt"),
       {
         ASSETS: {
           fetch: assetFetch,
@@ -50,6 +50,7 @@ describe("handleFetch", () => {
 
     expect(await response.text()).toBe("blob-body");
     expect(getAppFetch).toHaveBeenCalledTimes(1);
-    expect(assetFetch).toHaveBeenCalledTimes(1);
+    expect(assetFetch).toHaveBeenCalledTimes(0);
+    expect(new URL(getAppFetch.mock.calls[0][0].url).pathname).toBe("/blob/images/test.txt");
   });
 });

--- a/server/src/runtime/fetch-handler.ts
+++ b/server/src/runtime/fetch-handler.ts
@@ -1,6 +1,7 @@
 import { getApp } from "./app-instance";
 
 const ROOT_FEED_PATTERN = /^\/(rss\.xml|atom\.xml|rss\.json|feed\.json|feed\.xml)$/;
+const APP_PUBLIC_ROUTE_PATTERN = /^\/(favicon|favicon\.ico)(?:\/|$)/;
 
 function isApiRequest(pathname: string) {
   return pathname.startsWith("/api/");
@@ -14,6 +15,10 @@ function rewriteApiRequest(request: Request) {
 
 function isRootFeedRequest(pathname: string) {
   return ROOT_FEED_PATTERN.test(pathname);
+}
+
+function isAppPublicRoute(pathname: string) {
+  return APP_PUBLIC_ROUTE_PATTERN.test(pathname);
 }
 
 function isStaticAssetRequest(pathname: string) {
@@ -64,13 +69,15 @@ export async function handleFetch(request: Request, env: Env): Promise<Response>
     return getApp().fetch(rewriteApiRequest(request), env);
   }
 
+  if (isAppPublicRoute(pathname)) {
+    return getApp().fetch(request, env);
+  }
+
   if (isStaticAssetRequest(pathname)) {
     const asset = await tryServeAsset(request, env);
     if (asset) {
       return asset;
     }
-
-    return getApp().fetch(request, env);
   }
 
   const indexResponse = await serveSpaEntry(request, env);

--- a/server/src/runtime/fetch-handler.ts
+++ b/server/src/runtime/fetch-handler.ts
@@ -1,7 +1,6 @@
 import { getApp } from "./app-instance";
 
 const ROOT_FEED_PATTERN = /^\/(rss\.xml|atom\.xml|rss\.json|feed\.json|feed\.xml)$/;
-const APP_PUBLIC_ROUTE_PATTERN = /^\/(favicon|favicon\.ico)(?:\/|$)/;
 
 function isApiRequest(pathname: string) {
   return pathname.startsWith("/api/");
@@ -15,10 +14,6 @@ function rewriteApiRequest(request: Request) {
 
 function isRootFeedRequest(pathname: string) {
   return ROOT_FEED_PATTERN.test(pathname);
-}
-
-function isAppPublicRoute(pathname: string) {
-  return APP_PUBLIC_ROUTE_PATTERN.test(pathname);
 }
 
 function isStaticAssetRequest(pathname: string) {
@@ -69,15 +64,13 @@ export async function handleFetch(request: Request, env: Env): Promise<Response>
     return getApp().fetch(rewriteApiRequest(request), env);
   }
 
-  if (isAppPublicRoute(pathname)) {
-    return getApp().fetch(request, env);
-  }
-
   if (isStaticAssetRequest(pathname)) {
     const asset = await tryServeAsset(request, env);
     if (asset) {
       return asset;
     }
+
+    return getApp().fetch(request, env);
   }
 
   const indexResponse = await serveSpaEntry(request, env);

--- a/server/src/services/__tests__/storage.test.ts
+++ b/server/src/services/__tests__/storage.test.ts
@@ -192,7 +192,7 @@ describe('StorageService', () => {
             expect(payload.url).toMatch(/^https:\/\/images\.example\.com\/images\/[a-f0-9]+\.txt$/);
         });
 
-        it('should return a /blob URL when R2 is configured without S3_ACCESS_HOST', async () => {
+        it('should return an /api/blob URL when R2 is configured without S3_ACCESS_HOST', async () => {
             const putCalls: string[] = [];
             const r2Env = createMockEnv({
                 R2_BUCKET: {
@@ -232,7 +232,7 @@ describe('StorageService', () => {
             expect(putCalls).toHaveLength(1);
 
             const payload = await res.json() as { url: string };
-            expect(payload.url).toMatch(/^http:\/\/localhost\/blob\/images\/[a-f0-9]+\.txt$/);
+            expect(payload.url).toMatch(/^http:\/\/localhost\/api\/blob\/images\/[a-f0-9]+\.txt$/);
         });
 
         it('should return 500 when S3_ENDPOINT is not defined without R2 binding', async () => {

--- a/server/src/utils/storage.ts
+++ b/server/src/utils/storage.ts
@@ -63,7 +63,7 @@ function encodeStorageKey(key: string) {
 
 function buildBlobUrl(storageKey: string, baseUrl?: string) {
   const encodedKey = encodeStorageKey(storageKey);
-  const path = `/blob/${encodedKey}`;
+  const path = `/api/blob/${encodedKey}`;
 
   if (!baseUrl) {
     return path;


### PR DESCRIPTION
## Summary
- simplify fetch routing for dotted paths by trying static assets first and falling back to the app when the asset is missing
- remove the explicit public route allowlist for blob handling
- add runtime tests for both the asset-hit and asset-miss cases

## Verification
- cd server && bun run test
- cd server && bun run check
- cd client && bun run test
- cd client && bun run check
- cd client && bun run build
- bun run check
- bun run format:check