### PR TITLE
feat: add latest and popular sorting switch in hashtags page

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -716,5 +716,7 @@
       "warning": "Items to review"
     },
     "title": "Health Check"
-  }
+  },
+  "sort_latest": "Latest",
+  "sort_popular": "Popular"
 }

--- a/client/public/locales/ja/translation.json
+++ b/client/public/locales/ja/translation.json
@@ -707,5 +707,7 @@
       "warning": "確認すべき項目"
     },
     "title": "ヘルスチェック"
-  }
+  },
+  "sort_latest": "新着",
+  "sort_popular": "人気"
 }

--- a/client/public/locales/zh-CN/translation.json
+++ b/client/public/locales/zh-CN/translation.json
@@ -716,5 +716,7 @@
       "warning": "待检查项目"
     },
     "title": "健康检查"
-  }
+  },
+  "sort_latest": "最新",
+  "sort_popular": "热门"
 }

--- a/client/public/locales/zh-TW/translation.json
+++ b/client/public/locales/zh-TW/translation.json
@@ -716,5 +716,7 @@
       "warning": "待檢查項目"
     },
     "title": "健康檢查"
-  }
+  },
+  "sort_latest": "最新",
+  "sort_popular": "熱門"
 }

--- a/client/src/page/hashtags.tsx
+++ b/client/src/page/hashtags.tsx
@@ -20,7 +20,9 @@ export function HashtagsPage() {
     const { t } = useTranslation();
     const siteConfig = useSiteConfig();
     const [hashtags, setHashtags] = useState<Hashtag[]>();
+    const [sortBy, setSortBy] = useState<'latest' | 'popular'>('latest');
     const ref = useRef(false);
+
     useEffect(() => {
         if (ref.current) return;
         client.tag.list().then(({ data }) => {
@@ -29,7 +31,21 @@ export function HashtagsPage() {
             }
         });
         ref.current = true;
-    }, [])
+    }, []);
+
+    const sortedHashtags = hashtags
+        ?.filter(({ feeds }) => feeds > 0)
+        .sort((a, b) => {
+            if (sortBy === 'popular') {
+                if (b.feeds !== a.feeds) {
+                    return b.feeds - a.feeds;
+                }
+                return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+            } else {
+                return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+            }
+        });
+
     return (
         <>
             <Helmet>
@@ -42,17 +58,37 @@ export function HashtagsPage() {
             </Helmet>
             <Waiting for={hashtags}>
                 <main className="w-full flex flex-col justify-center items-center mb-8 ani-show">
-                    <div className="wauto text-start text-black dark:text-white py-4 text-4xl font-bold">
-                        <p>
+                    <div className="wauto text-start py-4 text-4xl font-bold">
+                        <p className="text-black dark:text-white">
                             {t('hashtags')}
                         </p>
+                        <div className="flex flex-row justify-between">
+                            <p className="text-sm mt-4 text-neutral-500 font-normal">
+                                {t('article.total$count', { count: sortedHashtags?.length || 0 })}
+                            </p>
+                            <div className="flex flex-row items-center space-x-3">
+                                <button
+                                    onClick={() => setSortBy('latest')}
+                                    className={`text-sm mt-4 text-neutral-500 font-normal transition-colors hover:text-theme ${sortBy === 'latest' ? "text-theme" : ""}`}
+                                >
+                                    {t('sort_latest')}
+                                </button>
+                                <span className="text-sm mt-4 text-neutral-300 dark:text-neutral-700 font-normal">|</span>
+                                <button
+                                    onClick={() => setSortBy('popular')}
+                                    className={`text-sm mt-4 text-neutral-500 font-normal transition-colors hover:text-theme ${sortBy === 'popular' ? "text-theme" : ""}`}
+                                >
+                                    {t('sort_popular')}
+                                </button>
+                            </div>
+                        </div>
                     </div>
 
-                    <div className="wauto flex flex-col flex-wrap items-start justify-start">
-                        {hashtags?.filter(({ feeds }) => feeds > 0).map((hashtag, index) => {
+                    <div className="wauto flex flex-col flex-wrap items-start justify-start mt-2">
+                        {sortedHashtags?.map((hashtag, index) => {
                             return (
                                 <div key={index} className="w-full flex flex-row">
-                                    <div className="w-full rounded-2xl m-2 duration-300 flex flex-row items-center space-x-4   ">
+                                    <div className="w-full rounded-2xl m-2 duration-300 flex flex-row items-center space-x-4">
                                         <Link href={`/hashtag/${hashtag.name}`} className="text-base t-primary hover:text-theme text-pretty overflow-hidden">
                                             <HashTag name={hashtag.name} />
                                         </Link>


### PR DESCRIPTION
Added a "Latest / Popular" sorting toggle to the hashtags page ([Live demo](https://antigonesemiotics.club/hashtags) — note: the demo defaults to 'Popular', while this PR retains 'Latest' as the default to preserve existing behavior).
在标签页新增了“最新 / 热门”排序切换功能（[在线示例](https://antigonesemiotics.club/hashtags)，注：示例站默认按热门排序，本 PR 为保持上游行为一致性，默认值已设为“最新”）。