### PR TITLE
fix: correct translation key for hashtag total count

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -718,5 +718,6 @@
     "title": "Health Check"
   },
   "sort_latest": "Latest",
-  "sort_popular": "Popular"
+  "sort_popular": "Popular",
+  "total_tags": "Total {{count}} tags"
 }

--- a/client/public/locales/ja/translation.json
+++ b/client/public/locales/ja/translation.json
@@ -709,5 +709,6 @@
     "title": "ヘルスチェック"
   },
   "sort_latest": "新着",
-  "sort_popular": "人気"
+  "sort_popular": "人気",
+  "total_tags": "全 {{count}} 個のタグ"
 }

--- a/client/public/locales/zh-CN/translation.json
+++ b/client/public/locales/zh-CN/translation.json
@@ -718,5 +718,6 @@
     "title": "健康检查"
   },
   "sort_latest": "最新",
-  "sort_popular": "热门"
+  "sort_popular": "热门",
+  "total_tags": "共 {{count}} 个标签"
 }

--- a/client/public/locales/zh-TW/translation.json
+++ b/client/public/locales/zh-TW/translation.json
@@ -718,5 +718,6 @@
     "title": "健康檢查"
   },
   "sort_latest": "最新",
-  "sort_popular": "熱門"
+  "sort_popular": "熱門",
+  "total_tags": "共 {{count}} 個標籤"
 }

--- a/client/src/page/hashtags.tsx
+++ b/client/src/page/hashtags.tsx
@@ -64,7 +64,7 @@ export function HashtagsPage() {
                         </p>
                         <div className="flex flex-row justify-between">
                             <p className="text-sm mt-4 text-neutral-500 font-normal">
-                                {t('article.total$count', { count: sortedHashtags?.length || 0 })}
+                                {t('total_tags', { count: sortedHashtags?.length || 0 })}
                             </p>
                             <div className="flex flex-row items-center space-x-3">
                                 <button


### PR DESCRIPTION
This PR fixes an oversight from the recent hashtag sorting update. The total count was incorrectly using the article count translation template, which displayed the count as "articles" instead of "tags".
修复了近期标签排序功能更新中的一个疏漏。原代码错误复用了文章总数的翻译模板，导致标签总数被错误地显示为“文章”而非“标签”。