### PR TITLE
feat: add agent API keys and bundled skill

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -546,10 +546,6 @@
     "wordpress": {
       "desc": "Upload the XML file exported from WordPress",
       "title": "Import from WordPress"
-    },
-    "mcp": {
-      "title": "MCP / Skill",
-      "desc": "Rin already exposes RESTful APIs for reading and writing posts. You can wrap these endpoints with a lightweight MCP server and pair them with a Skill prompt for external agents. See the MCP guide and examples in this repository."
     }
   },
   "sitename": "Site Name",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -4,6 +4,7 @@
     "title": "About"
   },
   "admin": {
+    "api_keys_description": "Create, review, and revoke API keys for external agents that need content access.",
     "back_to_site": "Back to site",
     "compat_tasks_description": "Run compatibility jobs in bulk to backfill missing AI summaries and image blurhash metadata for older posts.",
     "health_description": "Review required configuration, missing integrations, and risks that can affect runtime behavior.",
@@ -11,6 +12,64 @@
     "settings_description": "Manage site behavior, integrations, and publishing rules in one place.",
     "title": "Admin",
     "writing_description": "Write, edit, and publish content from the private management workspace."
+  },
+  "api_keys": {
+    "title": "API Keys",
+    "loading": "Loading API keys...",
+    "empty": "No API keys have been created yet.",
+    "copied": "Copied to clipboard.",
+    "never": "Never",
+    "revoke": "Revoke",
+    "create": {
+      "title": "Create Agent API Key",
+      "description": "Generate a bearer token for an external agent that needs to read or write Rin content.",
+      "name_label": "Label",
+      "name_placeholder": "Agent Writer",
+      "expiry_label": "Expiration",
+      "submit": "Create key",
+      "creating": "Creating..."
+    },
+    "expiry": {
+      "never": "Never expires",
+      "30d": "Expires in 30 days",
+      "90d": "Expires in 90 days"
+    },
+    "secret": {
+      "title": "Copy the secret now",
+      "description": "Rin only shows the full key once. Store it in your agent tool before dismissing this message.",
+      "copy": "Copy key",
+      "dismiss": "Dismiss"
+    },
+    "list": {
+      "title": "Existing keys",
+      "description": "Use this list to review active keys, last use, and expiration."
+    },
+    "status": {
+      "active": "Active",
+      "revoked": "Revoked"
+    },
+    "fields": {
+      "created_at": "Created: {{date}}",
+      "last_used_at": "Last used: {{date}}",
+      "expires_at": "Expires: {{date}}",
+      "capabilities": "Capabilities: {{scopes}}"
+    },
+    "docs": {
+      "title": "Agent setup",
+      "description": "Built-in instructions for external agents that use Rin with an API key.",
+      "scope_note": "These keys are intended for blog content workflows such as creating posts, updating drafts, publishing moments, and uploading media.",
+      "routes_note": "Admin configuration routes stay blocked for API-key auth. Use an interactive admin session for settings and diagnostics.",
+      "copy_curl": "Copy curl example",
+      "open_skill": "Open bundled skill"
+    },
+    "revoke_confirm": {
+      "title": "Revoke API key",
+      "description": "Revoke {{name}}? External agents using it will stop working immediately."
+    },
+    "errors": {
+      "name_required": "A label is required.",
+      "create_failed": "Failed to create API key."
+    }
   },
   "compat_tasks": {
     "title": "Compatibility Tasks",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -281,47 +281,47 @@
         "success": "Favicon update was successful"
       }
     },
-  "footer": {
-    "desc": "Set the footer content of the site (HTML)",
-    "title": "Footer"
-  },
-  "webhook": {
-    "title": "Webhook",
-    "url": {
-      "title": "Webhook URL",
-      "desc": "Set the webhook endpoint used for comment and friend-link notifications. Template variables are supported here too, which is useful for GET query strings."
+    "footer": {
+      "desc": "Set the footer content of the site (HTML)",
+      "title": "Footer"
     },
-    "method": {
-      "title": "Webhook Method",
-      "desc": "Set the HTTP method used for webhook requests, such as POST, PUT, or PATCH"
+    "webhook": {
+      "title": "Webhook",
+      "url": {
+        "title": "Webhook URL",
+        "desc": "Set the webhook endpoint used for comment and friend-link notifications. Template variables are supported here too, which is useful for GET query strings."
+      },
+      "method": {
+        "title": "Webhook Method",
+        "desc": "Set the HTTP method used for webhook requests, such as POST, PUT, or PATCH"
+      },
+      "content_type": {
+        "title": "Webhook Content-Type",
+        "desc": "Set the Content-Type header sent with webhook requests, for example application/json or text/plain"
+      },
+      "headers": {
+        "title": "Webhook Headers",
+        "desc": "Customize webhook headers as a JSON object template. Available variables are the same as the body template.",
+        "label": "Webhook headers JSON"
+      },
+      "body_template": {
+        "title": "Webhook Body Template",
+        "desc": "Customize the outgoing webhook payload. Available variables: {{event}}, {{message}}, {{title}}, {{url}}, {{username}}, {{content}}, {{description}}.",
+        "label": "Webhook body template"
+      },
+      "test": {
+        "title": "Send Test Webhook",
+        "desc": "Send a test request with the current webhook settings. Unsaved values in this page are used directly.",
+        "button": "Send Test",
+        "sending": "Sending...",
+        "placeholder": "Optional test message. Leave empty to use the default test payload.",
+        "success": "Webhook test sent successfully",
+        "failed": "Webhook test failed"
+      }
     },
-    "content_type": {
-      "title": "Webhook Content-Type",
-      "desc": "Set the Content-Type header sent with webhook requests, for example application/json or text/plain"
+    "maintenance": {
+      "title": "Maintenance"
     },
-    "headers": {
-      "title": "Webhook Headers",
-      "desc": "Customize webhook headers as a JSON object template. Available variables are the same as the body template.",
-      "label": "Webhook headers JSON"
-    },
-    "body_template": {
-      "title": "Webhook Body Template",
-      "desc": "Customize the outgoing webhook payload. Available variables: {{event}}, {{message}}, {{title}}, {{url}}, {{username}}, {{content}}, {{description}}.",
-      "label": "Webhook body template"
-    },
-    "test": {
-      "title": "Send Test Webhook",
-      "desc": "Send a test request with the current webhook settings. Unsaved values in this page are used directly.",
-      "button": "Send Test",
-      "sending": "Sending...",
-      "placeholder": "Optional test message. Leave empty to use the default test payload.",
-      "success": "Webhook test sent successfully",
-      "failed": "Webhook test failed"
-    }
-  },
-  "maintenance": {
-    "title": "Maintenance"
-  },
     "friend": {
       "apply": {
         "desc": "Allow other users to apply for friend links (requires review)",
@@ -487,6 +487,10 @@
     "wordpress": {
       "desc": "Upload the XML file exported from WordPress",
       "title": "Import from WordPress"
+    },
+    "mcp": {
+      "title": "MCP / Skill",
+      "desc": "Rin already exposes RESTful APIs for reading and writing posts. You can wrap these endpoints with a lightweight MCP server and pair them with a Skill prompt for external agents. See the MCP guide and examples in this repository."
     }
   },
   "sitename": "Site Name",
@@ -574,33 +578,33 @@
           "summary": "login.enabled is disabled.",
           "suggestion": "Enable login in settings if this instance needs interactive admin access."
         },
-      "missing": {
-        "impact": "Users can see the login entry but no working login method is configured.",
-        "summary": "Neither GitHub OAuth nor password login is configured.",
-        "suggestion": "Configure RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET or ADMIN_USERNAME/ADMIN_PASSWORD."
-      },
-      "default_password": {
-        "impact": "The admin account is still using the default username and password, which is a critical security risk.",
-        "summary": "ADMIN_USERNAME/ADMIN_PASSWORD are still set to admin / admin123.",
-        "suggestion": "Change the default username or password immediately before exposing the site."
-      },
-      "oauth_missing": {
-        "impact": "Only the local password account can sign in. Other users cannot log in and comment through OAuth.",
-        "summary": "GitHub OAuth is not configured.",
-        "suggestion": "Configure RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET if you expect other users to log in."
-      },
-      "ready": {
-        "impact": "Admin sign-in is available.",
-        "summary": "OAuth login is configured and the current password login configuration is not using the default credentials.",
-        "suggestion": "No action required."
-      },
-      "details": {
-        "github_configured": "GitHub OAuth: configured",
-        "github_missing": "GitHub OAuth: missing",
-        "password_configured": "Password login: configured",
-        "password_missing": "Password login: missing",
-        "password_default": "Password login: using default credentials"
-      }
+        "missing": {
+          "impact": "Users can see the login entry but no working login method is configured.",
+          "summary": "Neither GitHub OAuth nor password login is configured.",
+          "suggestion": "Configure RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET or ADMIN_USERNAME/ADMIN_PASSWORD."
+        },
+        "default_password": {
+          "impact": "The admin account is still using the default username and password, which is a critical security risk.",
+          "summary": "ADMIN_USERNAME/ADMIN_PASSWORD are still set to admin / admin123.",
+          "suggestion": "Change the default username or password immediately before exposing the site."
+        },
+        "oauth_missing": {
+          "impact": "Only the local password account can sign in. Other users cannot log in and comment through OAuth.",
+          "summary": "GitHub OAuth is not configured.",
+          "suggestion": "Configure RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET if you expect other users to log in."
+        },
+        "ready": {
+          "impact": "Admin sign-in is available.",
+          "summary": "OAuth login is configured and the current password login configuration is not using the default credentials.",
+          "suggestion": "No action required."
+        },
+        "details": {
+          "github_configured": "GitHub OAuth: configured",
+          "github_missing": "GitHub OAuth: missing",
+          "password_configured": "Password login: configured",
+          "password_missing": "Password login: missing",
+          "password_default": "Password login: using default credentials"
+        }
       },
       "storage": {
         "title": "Object storage",

--- a/client/public/locales/zh-CN/translation.json
+++ b/client/public/locales/zh-CN/translation.json
@@ -281,47 +281,47 @@
         "success": "网站图标更新成功"
       }
     },
-  "footer": {
-    "desc": "设置显示于站点底部的内容（HTML）",
-    "title": "站点底部内容"
-  },
-  "webhook": {
-    "title": "Webhook",
-    "url": {
-      "title": "Webhook 地址",
-      "desc": "设置评论和友链通知使用的 webhook 地址。这里同样支持模板变量，适合 GET 场景拼接 query string。"
+    "footer": {
+      "desc": "设置显示于站点底部的内容（HTML）",
+      "title": "站点底部内容"
     },
-    "method": {
-      "title": "Webhook Method",
-      "desc": "设置 webhook 请求使用的 HTTP Method，例如 GET、POST、PUT 或 PATCH"
+    "webhook": {
+      "title": "Webhook",
+      "url": {
+        "title": "Webhook 地址",
+        "desc": "设置评论和友链通知使用的 webhook 地址。这里同样支持模板变量，适合 GET 场景拼接 query string。"
+      },
+      "method": {
+        "title": "Webhook Method",
+        "desc": "设置 webhook 请求使用的 HTTP Method，例如 GET、POST、PUT 或 PATCH"
+      },
+      "content_type": {
+        "title": "Webhook Content-Type",
+        "desc": "设置 webhook 请求发送时使用的 Content-Type，例如 application/json 或 text/plain"
+      },
+      "headers": {
+        "title": "Webhook 请求头",
+        "desc": "以 JSON 模板自定义 webhook 请求头。可用变量与请求体模板一致。",
+        "label": "Webhook 请求头 JSON"
+      },
+      "body_template": {
+        "title": "Webhook 请求体模板",
+        "desc": "自定义 webhook 发出的请求体。可用变量：{{event}}、{{message}}、{{title}}、{{url}}、{{username}}、{{content}}、{{description}}。",
+        "label": "Webhook 请求体模板"
+      },
+      "test": {
+        "title": "发送测试 Webhook",
+        "desc": "使用当前页面里的 webhook 设置发送一次测试请求。未保存的修改也会直接生效。",
+        "button": "发送测试",
+        "sending": "发送中...",
+        "placeholder": "可选的测试消息内容。留空时会使用默认测试负载。",
+        "success": "Webhook 测试发送成功",
+        "failed": "Webhook 测试发送失败"
+      }
     },
-    "content_type": {
-      "title": "Webhook Content-Type",
-      "desc": "设置 webhook 请求发送时使用的 Content-Type，例如 application/json 或 text/plain"
+    "maintenance": {
+      "title": "维护"
     },
-    "headers": {
-      "title": "Webhook 请求头",
-      "desc": "以 JSON 模板自定义 webhook 请求头。可用变量与请求体模板一致。",
-      "label": "Webhook 请求头 JSON"
-    },
-    "body_template": {
-      "title": "Webhook 请求体模板",
-      "desc": "自定义 webhook 发出的请求体。可用变量：{{event}}、{{message}}、{{title}}、{{url}}、{{username}}、{{content}}、{{description}}。",
-      "label": "Webhook 请求体模板"
-    },
-    "test": {
-      "title": "发送测试 Webhook",
-      "desc": "使用当前页面里的 webhook 设置发送一次测试请求。未保存的修改也会直接生效。",
-      "button": "发送测试",
-      "sending": "发送中...",
-      "placeholder": "可选的测试消息内容。留空时会使用默认测试负载。",
-      "success": "Webhook 测试发送成功",
-      "failed": "Webhook 测试发送失败"
-    }
-  },
-  "maintenance": {
-    "title": "维护"
-  },
     "friend": {
       "apply": {
         "desc": "允许其他用户申请友链（需审核）",
@@ -487,6 +487,10 @@
     "wordpress": {
       "desc": "上传 WordPress 导出的 XML 文件",
       "title": "从 WordPress 导入"
+    },
+    "mcp": {
+      "title": "MCP / Skill",
+      "desc": "Rin 已经提供了读写文章所需的 RESTful API。你可以基于这些接口封装一层轻量 MCP 服务，再配合 Skill 提示文件供外部 Agent 调用。可参考仓库内的 MCP 指南与示例文件。"
     }
   },
   "sitename": "站点名称",
@@ -574,33 +578,33 @@
           "summary": "login.enabled 已关闭。",
           "suggestion": "如果此实例需要交互式后台访问，请在设置中启用登录。"
         },
-      "missing": {
-        "impact": "用户可以看到登录入口，但没有任何可用的登录方式。",
-        "summary": "GitHub OAuth 和密码登录都未配置。",
-        "suggestion": "请配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET 或 ADMIN_USERNAME/ADMIN_PASSWORD。"
-      },
-      "default_password": {
-        "impact": "管理员账号仍在使用默认用户名和密码，属于严重安全风险。",
-        "summary": "ADMIN_USERNAME/ADMIN_PASSWORD 仍然是 admin / admin123。",
-        "suggestion": "在公开站点前请立即修改默认用户名或密码。"
-      },
-      "oauth_missing": {
-        "impact": "当前只能使用本地密码账号登录，其他用户无法通过 OAuth 登录并评论。",
-        "summary": "GitHub OAuth 未配置。",
-        "suggestion": "如果希望其他用户登录，请配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET。"
-      },
-      "ready": {
-        "impact": "后台登录可用。",
-        "summary": "OAuth 登录已配置，且当前密码登录未使用默认凭据。",
-        "suggestion": "无需处理。"
-      },
-      "details": {
-        "github_configured": "GitHub OAuth：已配置",
-        "github_missing": "GitHub OAuth：未配置",
-        "password_configured": "密码登录：已配置",
-        "password_missing": "密码登录：未配置",
-        "password_default": "密码登录：使用默认凭据"
-      }
+        "missing": {
+          "impact": "用户可以看到登录入口，但没有任何可用的登录方式。",
+          "summary": "GitHub OAuth 和密码登录都未配置。",
+          "suggestion": "请配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET 或 ADMIN_USERNAME/ADMIN_PASSWORD。"
+        },
+        "default_password": {
+          "impact": "管理员账号仍在使用默认用户名和密码，属于严重安全风险。",
+          "summary": "ADMIN_USERNAME/ADMIN_PASSWORD 仍然是 admin / admin123。",
+          "suggestion": "在公开站点前请立即修改默认用户名或密码。"
+        },
+        "oauth_missing": {
+          "impact": "当前只能使用本地密码账号登录，其他用户无法通过 OAuth 登录并评论。",
+          "summary": "GitHub OAuth 未配置。",
+          "suggestion": "如果希望其他用户登录，请配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET。"
+        },
+        "ready": {
+          "impact": "后台登录可用。",
+          "summary": "OAuth 登录已配置，且当前密码登录未使用默认凭据。",
+          "suggestion": "无需处理。"
+        },
+        "details": {
+          "github_configured": "GitHub OAuth：已配置",
+          "github_missing": "GitHub OAuth：未配置",
+          "password_configured": "密码登录：已配置",
+          "password_missing": "密码登录：未配置",
+          "password_default": "密码登录：使用默认凭据"
+        }
       },
       "storage": {
         "title": "对象存储",

--- a/client/public/skills/rin-agent/SKILL.md
+++ b/client/public/skills/rin-agent/SKILL.md
@@ -1,0 +1,76 @@
+# Rin Agent Access
+
+Use this skill when you need to read or update Rin blog content through a user-provided API key.
+
+## Required Inputs
+
+- `RIN_BASE_URL`: the public base URL of the Rin site, for example `https://blog.example.com`
+- `RIN_API_KEY`: an API key created from Rin admin at `/admin/api-keys`
+
+Send the API key as a bearer token on every request:
+
+```http
+Authorization: Bearer <RIN_API_KEY>
+```
+
+## Supported Content Workflows
+
+### List published posts
+
+`GET {{RIN_BASE_URL}}/api/feed`
+
+### Read a post
+
+`GET {{RIN_BASE_URL}}/api/feed/:id`
+
+`id` can be the numeric id or the post alias.
+
+### Create a post
+
+`POST {{RIN_BASE_URL}}/api/feed`
+
+```json
+{
+  "title": "Agent draft",
+  "content": "# Hello from Rin",
+  "summary": "Created by an external agent",
+  "draft": true,
+  "listed": false,
+  "tags": []
+}
+```
+
+### Update a post
+
+`POST {{RIN_BASE_URL}}/api/feed/:id`
+
+Send the same shape used for create, with the fields you want to change.
+
+### Delete a post
+
+`DELETE {{RIN_BASE_URL}}/api/feed/:id`
+
+### Create a moment
+
+`POST {{RIN_BASE_URL}}/api/moments`
+
+```json
+{
+  "content": "Short update from an external agent."
+}
+```
+
+### Upload media
+
+`POST {{RIN_BASE_URL}}/api/storage`
+
+Use `multipart/form-data` with:
+
+- `file`: the uploaded file
+- `key`: optional original filename
+
+## Constraints
+
+- These API keys are intended for content workflows, not site-wide settings changes.
+- Treat the key as a secret. Rin only shows the full value once when the key is created.
+- If a request returns `401` or `403`, ask the user to verify the key is still active in `/admin/api-keys`.

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -33,6 +33,10 @@ import type {
   AuthStatus,
   LoginRequest,
   LoginResponse,
+  ApiKeyListResponse,
+  CreateApiKeyRequest,
+  CreateApiKeyResponse,
+  RevokeApiKeyResponse,
 } from "@rin/api";
 
 export interface SettingsConfigResponse {
@@ -155,6 +159,10 @@ export type {
   AuthStatus,
   LoginRequest,
   LoginResponse,
+  ApiKeyListResponse,
+  CreateApiKeyRequest,
+  CreateApiKeyResponse,
+  RevokeApiKeyResponse,
 } from "@rin/api";
 
 
@@ -538,6 +546,22 @@ class ConfigAPI {
   }
 }
 
+class ApiKeysAPI {
+  constructor(private http: HttpClient) {}
+
+  async list(): Promise<ApiResponse<ApiKeyListResponse>> {
+    return this.http.get<ApiKeyListResponse>("/api/api-keys");
+  }
+
+  async create(body: CreateApiKeyRequest): Promise<ApiResponse<CreateApiKeyResponse>> {
+    return this.http.post<CreateApiKeyResponse>("/api/api-keys", body);
+  }
+
+  async revoke(id: number): Promise<ApiResponse<RevokeApiKeyResponse>> {
+    return this.http.post<RevokeApiKeyResponse>(`/api/api-keys/${id}/revoke`);
+  }
+}
+
 /**
  * AI Config API methods (deprecated, use ConfigAPI instead)
  * @deprecated AI config is now part of server config. Use client.config.get('server') and client.config.update('server', {...}) instead.
@@ -658,6 +682,7 @@ export class ApiClient {
   friend: FriendAPI;
   moments: MomentsAPI;
   config: ConfigAPI;
+  apiKeys: ApiKeysAPI;
   aiConfig: AIConfigAPI;
   storage: StorageAPI;
   search: SearchAPI;
@@ -674,6 +699,7 @@ export class ApiClient {
     this.friend = new FriendAPI(this.http);
     this.moments = new MomentsAPI(this.http);
     this.config = new ConfigAPI(this.http);
+    this.apiKeys = new ApiKeysAPI(this.http);
     this.aiConfig = new AIConfigAPI(this.http);
     this.storage = new StorageAPI(this.http);
     this.search = new SearchAPI(this.http);

--- a/client/src/app/routes.tsx
+++ b/client/src/app/routes.tsx
@@ -24,6 +24,7 @@ import { MomentsPage } from "../page/moments";
 import { ProfilePage } from "../page/profile";
 import { QueueStatusPage } from "../page/queue-status";
 import { SearchPage } from "../page/search";
+import { ApiKeysPage } from "../page/api-keys";
 import { Settings } from "../page/settings";
 import { TimelinePage } from "../page/timeline";
 import { WritingPage } from "../page/writing";
@@ -66,6 +67,10 @@ export function AppRoutes() {
 
       <AdminRoute path="/admin/settings" requirePermission title={t("settings.title")} description={t("admin.settings_description")}>
         <Settings />
+      </AdminRoute>
+
+      <AdminRoute path="/admin/api-keys" requirePermission title={t("api_keys.title")} description={t("admin.api_keys_description")}>
+        <ApiKeysPage />
       </AdminRoute>
 
       <AdminRoute path="/admin/health" requirePermission title={t("health.title")} description={t("admin.health_description")}>

--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -64,6 +64,7 @@ export function AdminLayout({
               <div className="mt-3 flex flex-col gap-2">
                 <AdminNavItem href="/admin/writing" icon="ri-quill-pen-line" label={t("writing")} />
                 <AdminNavItem href="/admin/settings" icon="ri-settings-3-line" label={t("settings.title")} />
+                <AdminNavItem href="/admin/api-keys" icon="ri-key-2-line" label={t("api_keys.title")} />
                 <AdminNavItem href="/admin/health" icon="ri-heart-pulse-line" label={t("health.title")} />
                 <AdminNavItem href="/admin/queue-status" icon="ri-todo-line" label={t("queue_status.title")} />
                 <AdminNavItem href="/admin/compat-tasks" icon="ri-history-line" label={t("compat_tasks.title")} />

--- a/client/src/page/api-keys.tsx
+++ b/client/src/page/api-keys.tsx
@@ -1,0 +1,287 @@
+import { SettingsBadge, SettingsCard, SettingsCardBody, SettingsCardHeader, SettingsCardRow } from "@rin/ui";
+import type { ApiKeyRecord } from "@rin/api";
+import { useEffect, useMemo, useState } from "react";
+import { Helmet } from "react-helmet";
+import { useTranslation } from "react-i18next";
+import ReactLoading from "react-loading";
+import { client } from "../app/runtime";
+import { Button } from "../components/button";
+import { useAlert, useConfirm } from "../components/dialog";
+import { useSiteConfig } from "../hooks/useSiteConfig";
+
+type ExpiryOption = "never" | "30d" | "90d";
+
+function buildExpiryDate(option: ExpiryOption) {
+  if (option === "never") {
+    return null;
+  }
+
+  const now = new Date();
+  const days = option === "30d" ? 30 : 90;
+  now.setDate(now.getDate() + days);
+  return now.toISOString();
+}
+
+function formatDate(value: string | null, t: ReturnType<typeof useTranslation>["t"]) {
+  if (!value) {
+    return t("api_keys.never");
+  }
+
+  return new Date(value).toLocaleString();
+}
+
+export function ApiKeysPage() {
+  const { t } = useTranslation();
+  const siteConfig = useSiteConfig();
+  const { showAlert, AlertUI } = useAlert();
+  const { showConfirm, ConfirmUI } = useConfirm();
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [items, setItems] = useState<ApiKeyRecord[]>([]);
+  const [name, setName] = useState("");
+  const [expiry, setExpiry] = useState<ExpiryOption>("never");
+  const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+
+  const skillUrl = useMemo(() => {
+    if (typeof window === "undefined") {
+      return "/skills/rin-agent/SKILL.md";
+    }
+
+    return new URL("/skills/rin-agent/SKILL.md", window.location.origin).toString();
+  }, []);
+
+  const apiBaseUrl = useMemo(() => {
+    if (typeof window === "undefined") {
+      return "";
+    }
+
+    return window.location.origin;
+  }, []);
+
+  async function loadApiKeys() {
+    setLoading(true);
+    try {
+      const { data, error } = await client.apiKeys.list();
+      if (error) {
+        throw new Error(error.value);
+      }
+      setItems(data?.items ?? []);
+    } catch (error) {
+      showAlert(error instanceof Error ? error.message : String(error));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadApiKeys();
+  }, []);
+
+  async function handleCreate() {
+    if (!name.trim()) {
+      showAlert(t("api_keys.errors.name_required"));
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const { data, error } = await client.apiKeys.create({
+        name: name.trim(),
+        expiresAt: buildExpiryDate(expiry),
+      });
+
+      if (error || !data) {
+        throw new Error(error?.value ?? t("api_keys.errors.create_failed"));
+      }
+
+      setCreatedSecret(data.secret);
+      setItems((current) => [data.apiKey, ...current]);
+      setName("");
+      setExpiry("never");
+    } catch (error) {
+      showAlert(error instanceof Error ? error.message : String(error));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function copyText(value: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      showAlert(t("api_keys.copied"));
+    } catch (error) {
+      showAlert(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  async function handleRevoke(id: number) {
+    const { error } = await client.apiKeys.revoke(id);
+    if (error) {
+      throw new Error(error.value);
+    }
+
+    setItems((current) =>
+      current.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              revokedAt: new Date().toISOString(),
+            }
+          : item,
+      ),
+    );
+  }
+
+  const exampleToken = createdSecret ?? "rin_your_api_key_here";
+  const curlExample = `curl -X POST '${apiBaseUrl}/api/feed' \\
+  -H 'Authorization: Bearer ${exampleToken}' \\
+  -H 'Content-Type: application/json' \\
+  -d '{"title":"Agent draft","content":"# Hello from Rin","summary":"Created by an external agent","draft":true,"listed":false,"tags":[]}'`;
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <Helmet>
+        <title>{`${t("api_keys.title")} - ${siteConfig.name}`}</title>
+      </Helmet>
+
+      <SettingsCard>
+        <SettingsCardHeader title={t("api_keys.create.title")} description={t("api_keys.create.description")} />
+        <SettingsCardBody>
+          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_220px_auto]">
+            <label className="flex flex-col gap-2 text-sm t-primary">
+              <span>{t("api_keys.create.name_label")}</span>
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder={t("api_keys.create.name_placeholder")}
+                className="rounded-xl border border-black/10 bg-w px-4 py-3 outline-none focus:border-black/20 dark:border-white/10 dark:focus:border-white/20"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm t-primary">
+              <span>{t("api_keys.create.expiry_label")}</span>
+              <select
+                value={expiry}
+                onChange={(event) => setExpiry(event.target.value as ExpiryOption)}
+                className="rounded-xl border border-black/10 bg-w px-4 py-3 outline-none focus:border-black/20 dark:border-white/10 dark:focus:border-white/20"
+              >
+                <option value="never">{t("api_keys.expiry.never")}</option>
+                <option value="30d">{t("api_keys.expiry.30d")}</option>
+                <option value="90d">{t("api_keys.expiry.90d")}</option>
+              </select>
+            </label>
+            <div className="flex items-end">
+              <Button title={submitting ? t("api_keys.create.creating") : t("api_keys.create.submit")} onClick={() => void handleCreate()} />
+            </div>
+          </div>
+        </SettingsCardBody>
+      </SettingsCard>
+
+      {createdSecret ? (
+        <SettingsCard tone="warning">
+          <SettingsCardHeader title={t("api_keys.secret.title")} description={t("api_keys.secret.description")} />
+          <SettingsCardBody>
+            <div className="flex flex-col gap-3">
+              <code className="overflow-x-auto rounded-xl bg-black px-4 py-3 text-sm text-white">{createdSecret}</code>
+              <div className="flex gap-3">
+                <Button title={t("api_keys.secret.copy")} onClick={() => void copyText(createdSecret)} />
+                <Button secondary title={t("api_keys.secret.dismiss")} onClick={() => setCreatedSecret(null)} />
+              </div>
+            </div>
+          </SettingsCardBody>
+        </SettingsCard>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <div className="space-y-4">
+          <SettingsCard>
+            <SettingsCardHeader title={t("api_keys.list.title")} description={t("api_keys.list.description")} />
+            <SettingsCardBody>
+              {loading ? (
+                <div className="flex items-center gap-3 py-4 text-sm text-neutral-500 dark:text-neutral-400">
+                  <ReactLoading width="1.25em" height="1.25em" type="spin" color="#FC466B" />
+                  <span>{t("api_keys.loading")}</span>
+                </div>
+              ) : null}
+
+              {!loading && items.length === 0 ? <p className="text-sm text-neutral-500 dark:text-neutral-400">{t("api_keys.empty")}</p> : null}
+
+              {!loading && items.length > 0 ? (
+                <div className="space-y-3">
+                  {items.map((item) => (
+                    <SettingsCard key={item.id} tone={item.revokedAt ? "warning" : "default"}>
+                      <SettingsCardRow
+                        header={
+                          <SettingsCardHeader
+                            title={item.name}
+                            description={`${item.keyPrefix}...`}
+                            badge={
+                              <SettingsBadge tone={item.revokedAt ? "neutral" : "success"}>
+                                {item.revokedAt ? t("api_keys.status.revoked") : t("api_keys.status.active")}
+                              </SettingsBadge>
+                            }
+                          />
+                        }
+                        action={
+                          item.revokedAt ? null : (
+                            <Button
+                              secondary
+                              title={t("api_keys.revoke")}
+                              onClick={() => {
+                                showConfirm(
+                                  t("api_keys.revoke_confirm.title"),
+                                  t("api_keys.revoke_confirm.description", { name: item.name }),
+                                  () => handleRevoke(item.id),
+                                );
+                              }}
+                            />
+                          )
+                        }
+                      />
+                      <SettingsCardBody>
+                        <div className="grid gap-2 text-sm text-neutral-600 dark:text-neutral-300 md:grid-cols-2">
+                          <p>{t("api_keys.fields.created_at", { date: formatDate(item.createdAt, t) })}</p>
+                          <p>{t("api_keys.fields.last_used_at", { date: formatDate(item.lastUsedAt, t) })}</p>
+                          <p>{t("api_keys.fields.expires_at", { date: formatDate(item.expiresAt, t) })}</p>
+                          <p>{t("api_keys.fields.capabilities", { scopes: item.scopes.join(", ") })}</p>
+                        </div>
+                      </SettingsCardBody>
+                    </SettingsCard>
+                  ))}
+                </div>
+              ) : null}
+            </SettingsCardBody>
+          </SettingsCard>
+        </div>
+
+        <div className="space-y-4">
+          <SettingsCard>
+            <SettingsCardHeader title={t("api_keys.docs.title")} description={t("api_keys.docs.description")} />
+            <SettingsCardBody>
+              <div className="space-y-3 text-sm text-neutral-600 dark:text-neutral-300">
+                <p>{t("api_keys.docs.scope_note")}</p>
+                <p>{t("api_keys.docs.routes_note")}</p>
+                <pre className="overflow-x-auto rounded-xl bg-black px-4 py-3 text-xs text-white">
+                  <code>{curlExample}</code>
+                </pre>
+                <div className="flex flex-wrap gap-3">
+                  <Button title={t("api_keys.docs.copy_curl")} onClick={() => void copyText(curlExample)} />
+                  <a
+                    href={skillUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center rounded-xl border border-black/10 px-4 py-2 text-sm font-medium t-primary transition-colors hover:bg-neutral-100 dark:border-white/10 dark:hover:bg-white/5"
+                  >
+                    {t("api_keys.docs.open_skill")}
+                  </a>
+                </div>
+              </div>
+            </SettingsCardBody>
+          </SettingsCard>
+        </div>
+      </div>
+
+      <AlertUI />
+      <ConfirmUI />
+    </div>
+  );
+}

--- a/client/src/page/settings.tsx
+++ b/client/src/page/settings.tsx
@@ -545,19 +545,6 @@ export function Settings() {
               <SettingsCardRow
                 header={
                   <SettingsCardHeader
-                    title={t("settings.mcp.title")}
-                    description={t("settings.mcp.desc")}
-                  />
-                }
-              />
-            </SettingsCard>
-          </div>
-
-          <div className="w-full">
-            <SettingsCard>
-              <SettingsCardRow
-                header={
-                  <SettingsCardHeader
                     title={t("settings.webhook.test.title")}
                     description={t("settings.webhook.test.desc")}
                   />

--- a/client/src/page/settings.tsx
+++ b/client/src/page/settings.tsx
@@ -545,6 +545,19 @@ export function Settings() {
               <SettingsCardRow
                 header={
                   <SettingsCardHeader
+                    title={t("settings.mcp.title")}
+                    description={t("settings.mcp.desc")}
+                  />
+                }
+              />
+            </SettingsCard>
+          </div>
+
+          <div className="w-full">
+            <SettingsCard>
+              <SettingsCardRow
+                header={
+                  <SettingsCardHeader
                     title={t("settings.webhook.test.title")}
                     description={t("settings.webhook.test.desc")}
                   />

--- a/docs/docs/en/_nav.json
+++ b/docs/docs/en/_nav.json
@@ -5,6 +5,7 @@
       { "text": "Introduction", "link": "/guide/" },
       { "text": "Deploy", "link": "/guide/deploy" },
       { "text": "Development", "link": "/guide/development" },
+      { "text": "MCP Integration", "link": "/guide/mcp" },
       { "text": "Webhook", "link": "/guide/webhook" },
       { "text": "RSS", "link": "/guide/rss" },
       { "text": "Migration", "link": "/guide/migration" },

--- a/docs/docs/en/guide/_meta.json
+++ b/docs/docs/en/guide/_meta.json
@@ -2,6 +2,7 @@
   "index",
   "deploy",
   "development",
+  "mcp",
   "webhook",
   "rss",
   "migration",

--- a/docs/docs/en/guide/mcp.md
+++ b/docs/docs/en/guide/mcp.md
@@ -1,0 +1,65 @@
+# MCP Integration
+
+Rin already exposes REST-style JSON endpoints for the web app and admin writing flow. If you want external agents to read posts, draft content, or publish updates, the practical approach is to wrap the existing HTTP API with a small MCP server and pair it with a Skill prompt.
+
+This means:
+
+- Rin remains the content system of record
+- your MCP layer translates agent tool calls into Rin HTTP requests
+- you do not need to add a second content backend just for agent workflows
+
+## What Already Exists
+
+The current admin UI already uses backend endpoints such as:
+
+- `GET /api/feed`: list published posts by default
+- `GET /api/feed/:id`: read a single post by numeric ID or alias
+- `POST /api/feed`: create a new post or draft
+- `POST /api/feed/:id`: update an existing post
+
+Published-read access is available from the public API. Draft creation and post updates require an authenticated admin session.
+
+## Admin Setup
+
+If you want an external agent to write through Rin:
+
+1. Enable a normal admin login path for the instance.
+2. Authenticate once with `POST /api/auth/login` or your existing GitHub-based admin flow.
+3. Pass the returned bearer token, or the `token` cookie, through your MCP wrapper when calling admin-only endpoints.
+4. Limit the wrapper to the minimum tools you actually want agents to use.
+
+Rin does not currently ship a dedicated long-lived API key for content writing. The MCP wrapper should therefore operate on behalf of an authenticated admin account.
+
+## Suggested MCP Tool Surface
+
+Keep the first version narrow:
+
+- `list_posts`: call `GET /api/feed?page=1&limit=20`
+- `get_post`: call `GET /api/feed/:id`
+- `create_draft`: call `POST /api/feed` with `draft: true`
+- `update_post`: call `POST /api/feed/:id`
+
+This is enough for most editorial agent flows:
+
+- fetch recent posts for context
+- inspect one post in full
+- draft a new article
+- revise an existing draft or published post
+
+## Example Files
+
+This repository includes minimal wrapper examples in [`examples/mcp/openrin-blog.mcp.json`](../../../examples/mcp/openrin-blog.mcp.json) and [`examples/mcp/openrin-blog-writer.SKILL.md`](../../../examples/mcp/openrin-blog-writer.SKILL.md).
+
+They are intentionally small:
+
+- the JSON file describes a thin MCP-style tool mapping over Rin's existing HTTP API
+- the Skill file shows how another agent can use those tools safely for reading and writing blog content
+
+These files are examples, not a bundled production MCP server.
+
+## Operational Notes
+
+- Treat `create_draft` as the default write path. Publish only after review.
+- Preserve Rin fields such as `title`, `content`, `summary`, `tags`, `alias`, `draft`, and `listed`.
+- Use aliases carefully because `GET /api/feed/:id` accepts either numeric IDs or aliases.
+- If your wrapper is exposed to multiple agents, add your own audit logging and permission controls at the MCP layer.

--- a/docs/docs/zh/_nav.json
+++ b/docs/docs/zh/_nav.json
@@ -5,6 +5,7 @@
       { "text": "简介", "link": "/guide/" },
       { "text": "部署", "link": "/guide/deploy" },
       { "text": "本地开发", "link": "/guide/development" },
+      { "text": "MCP 集成", "link": "/guide/mcp" },
       { "text": "Webhook", "link": "/guide/webhook" },
       { "text": "RSS", "link": "/guide/rss" },
       { "text": "迁移指南", "link": "/guide/migration" },

--- a/docs/docs/zh/guide/_meta.json
+++ b/docs/docs/zh/guide/_meta.json
@@ -2,6 +2,7 @@
   "index",
   "deploy",
   "development",
+  "mcp",
   "webhook",
   "rss",
   "migration",

--- a/docs/docs/zh/guide/mcp.md
+++ b/docs/docs/zh/guide/mcp.md
@@ -1,0 +1,65 @@
+# MCP 集成
+
+Rin 已经提供了供前端和后台写作流程使用的 REST 风格 JSON 接口。如果你希望外部 Agent 读取文章、起草内容或发布更新，更实际的做法是为现有 HTTP API 包一层轻量 MCP 服务，再配一个 Skill 提示文件。
+
+这意味着：
+
+- Rin 仍然是内容的唯一真实来源
+- MCP 层只负责把 Agent 的工具调用翻译成 Rin 的 HTTP 请求
+- 不需要为了 Agent 工作流再额外做一套内容后台
+
+## 已有能力
+
+当前后台 UI 已经在使用这些接口：
+
+- `GET /api/feed`：默认列出已发布文章
+- `GET /api/feed/:id`：按数字 ID 或 alias 读取单篇文章
+- `POST /api/feed`：创建文章或草稿
+- `POST /api/feed/:id`：更新已有文章
+
+公开文章可通过公共 API 读取。草稿创建和文章更新需要管理员认证。
+
+## 后台接入方式
+
+如果你希望外部 Agent 通过 Rin 写作：
+
+1. 先保证实例有可用的管理员登录方式。
+2. 通过 `POST /api/auth/login` 或现有 GitHub 管理员登录流程完成一次认证。
+3. 在 MCP 包装层转发返回的 bearer token，或 `token` Cookie，去调用仅管理员可用的接口。
+4. 包装层只暴露真正需要的最小工具集合。
+
+Rin 目前没有单独提供长期有效的内容写作 API Key，因此 MCP 包装层应当代表一个已认证的管理员账号工作。
+
+## 建议的 MCP 工具面
+
+第一版尽量收敛到四个工具：
+
+- `list_posts`：调用 `GET /api/feed?page=1&limit=20`
+- `get_post`：调用 `GET /api/feed/:id`
+- `create_draft`：调用 `POST /api/feed`，并设置 `draft: true`
+- `update_post`：调用 `POST /api/feed/:id`
+
+这已经足够覆盖大多数编辑型 Agent 场景：
+
+- 拉取最近文章作为上下文
+- 读取单篇全文
+- 起草新文章
+- 修改已有草稿或已发布文章
+
+## 示例文件
+
+仓库里提供了两个最小示例：[`examples/mcp/openrin-blog.mcp.json`](../../../examples/mcp/openrin-blog.mcp.json) 和 [`examples/mcp/openrin-blog-writer.SKILL.md`](../../../examples/mcp/openrin-blog-writer.SKILL.md)。
+
+它们刻意保持轻量：
+
+- JSON 文件描述了一层基于 Rin 现有 HTTP API 的薄 MCP 映射
+- Skill 文件展示了其他 Agent 如何安全地使用这些工具读写博客内容
+
+这些文件是示例，不是仓库内置的生产级 MCP Server。
+
+## 运行建议
+
+- 默认把 `create_draft` 作为写入入口，审核后再发布。
+- 保留 Rin 现有字段：`title`、`content`、`summary`、`tags`、`alias`、`draft`、`listed`。
+- `GET /api/feed/:id` 同时接受数字 ID 和 alias，包装层需要注意区分。
+- 如果 MCP 包装层会给多个 Agent 使用，建议在包装层补充审计日志和权限限制。

--- a/examples/mcp/openrin-blog-writer.SKILL.md
+++ b/examples/mcp/openrin-blog-writer.SKILL.md
@@ -1,0 +1,58 @@
+# openrin-blog-writer
+
+Use this skill when an agent needs to read existing Rin posts for context, create a draft, or update an existing post through an MCP wrapper around Rin's REST API.
+
+## Assumptions
+
+- The MCP server exposes these tools: `list_posts`, `get_post`, `create_draft`, `update_post`.
+- Write tools already forward a valid Rin admin bearer token or admin session cookie.
+- Rin remains the source of truth. Do not invent fields that Rin does not store.
+
+## Workflow
+
+1. Start with `list_posts` when recent editorial context matters.
+2. Use `get_post` before editing an existing article.
+3. Default to `create_draft` for new long-form writing.
+4. Use `update_post` only after preserving the post's intended status fields such as `draft`, `listed`, `alias`, and `tags`.
+
+## Writing Rules
+
+- Keep markdown clean and publishable.
+- Preserve front-of-house details the editor would care about: title quality, summary, tags, alias, and whether the post should stay unlisted.
+- If the request is ambiguous, create a draft instead of silently overwriting a published post.
+- Do not remove substantive sections from an existing post unless the user explicitly asks for that change.
+
+## Tooling Notes
+
+- `get_post` accepts either a numeric ID or an alias.
+- `create_draft` should generally send `draft: true` and `listed: false`.
+- `update_post` can be used for both drafts and published posts, so pass status fields intentionally.
+
+## Example Requests
+
+Create a draft:
+
+```json
+{
+  "title": "Shipping an MCP wrapper for Rin",
+  "content": "# Shipping an MCP wrapper for Rin\n\nDraft body here.",
+  "summary": "How to wrap Rin's existing REST API for external agents.",
+  "tags": ["rin", "mcp", "agents"],
+  "alias": "rin-mcp-wrapper"
+}
+```
+
+Update a draft:
+
+```json
+{
+  "id": 42,
+  "title": "Shipping an MCP wrapper for Rin",
+  "content": "# Shipping an MCP wrapper for Rin\n\nRevised draft body.",
+  "summary": "Updated draft summary.",
+  "tags": ["rin", "mcp", "agents"],
+  "alias": "rin-mcp-wrapper",
+  "draft": true,
+  "listed": false
+}
+```

--- a/examples/mcp/openrin-blog.mcp.json
+++ b/examples/mcp/openrin-blog.mcp.json
@@ -1,0 +1,81 @@
+{
+  "name": "openrin-blog",
+  "version": "0.1.0",
+  "description": "Example MCP wrapper spec for exposing Rin blog reading and writing workflows to external agents.",
+  "transport": {
+    "type": "http",
+    "base_url_env": "RIN_BASE_URL"
+  },
+  "auth": {
+    "type": "bearer",
+    "token_env": "RIN_ADMIN_TOKEN",
+    "notes": [
+      "Obtain this token from Rin's admin login flow at POST /api/auth/login, or forward the admin token cookie through your MCP bridge.",
+      "Read-only feed endpoints can be called without authentication, but write tools should always send admin credentials."
+    ]
+  },
+  "tools": [
+    {
+      "name": "list_posts",
+      "description": "List recent published posts for context gathering.",
+      "request": {
+        "method": "GET",
+        "path": "/api/feed",
+        "query": {
+          "page": "{{page|default:1}}",
+          "limit": "{{limit|default:20}}"
+        }
+      }
+    },
+    {
+      "name": "get_post",
+      "description": "Fetch a full Rin post by numeric ID or alias.",
+      "request": {
+        "method": "GET",
+        "path": "/api/feed/{{id_or_alias}}"
+      }
+    },
+    {
+      "name": "create_draft",
+      "description": "Create a new draft in Rin.",
+      "request": {
+        "method": "POST",
+        "path": "/api/feed",
+        "headers": {
+          "Authorization": "Bearer {{env.RIN_ADMIN_TOKEN}}",
+          "Content-Type": "application/json"
+        },
+        "json_body": {
+          "title": "{{title}}",
+          "content": "{{content}}",
+          "summary": "{{summary|default:''}}",
+          "alias": "{{alias|default:null}}",
+          "draft": true,
+          "listed": false,
+          "tags": "{{tags|default:[]}}"
+        }
+      }
+    },
+    {
+      "name": "update_post",
+      "description": "Update an existing Rin post or draft.",
+      "request": {
+        "method": "POST",
+        "path": "/api/feed/{{id}}",
+        "headers": {
+          "Authorization": "Bearer {{env.RIN_ADMIN_TOKEN}}",
+          "Content-Type": "application/json"
+        },
+        "json_body": {
+          "title": "{{title}}",
+          "content": "{{content}}",
+          "summary": "{{summary|default:''}}",
+          "alias": "{{alias|default:null}}",
+          "draft": "{{draft|default:true}}",
+          "listed": "{{listed|default:false}}",
+          "tags": "{{tags|default:[]}}"
+        }
+      }
+    }
+  ]
+}

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -141,6 +141,44 @@ export interface LoginResponse {
 }
 
 // ============================================================================
+// API Key Types
+// ============================================================================
+
+export interface ApiKeyRecord {
+  id: number;
+  name: string;
+  keyPrefix: string;
+  scopes: string[];
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdByUser: {
+    id: number;
+    username: string;
+  } | null;
+}
+
+export interface ApiKeyListResponse {
+  items: ApiKeyRecord[];
+}
+
+export interface CreateApiKeyRequest {
+  name: string;
+  expiresAt?: string | null;
+}
+
+export interface CreateApiKeyResponse {
+  secret: string;
+  apiKey: ApiKeyRecord;
+}
+
+export interface RevokeApiKeyResponse {
+  success: boolean;
+}
+
+// ============================================================================
 // Tag Types
 // ============================================================================
 

--- a/server/sql/0010.sql
+++ b/server/sql/0010.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    key_prefix TEXT NOT NULL,
+    key_hash TEXT NOT NULL UNIQUE,
+    scopes TEXT DEFAULT '[]' NOT NULL,
+    created_by_uid INTEGER NOT NULL,
+    last_used_at INTEGER,
+    expires_at INTEGER,
+    revoked_at INTEGER,
+    created_at INTEGER DEFAULT (unixepoch()) NOT NULL,
+    updated_at INTEGER DEFAULT (unixepoch()) NOT NULL,
+    FOREIGN KEY (created_by_uid) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/server/src/core/hono-middleware.ts
+++ b/server/src/core/hono-middleware.ts
@@ -3,7 +3,7 @@ import { createMiddleware } from "hono/factory";
 import { getCookie, setCookie } from "hono/cookie";
 import { drizzle } from "drizzle-orm/d1";
 import type { AppContext, Variables, JWTUtils, OAuth2Utils } from "./hono-types";
-import { eq } from "drizzle-orm";
+import { and, eq, gt, isNull, or } from "drizzle-orm";
 import { profileAsync } from "./server-timing";
 
 // Lazy initialization container
@@ -97,6 +97,8 @@ export const initContainerMiddleware = createMiddleware<{
         c.set('jwt', jwt);
         c.set('oauth2', oauth2);
         c.set('admin', false);
+        c.set('authType', undefined);
+        c.set('apiKeyScopes', undefined);
         c.set('env', c.env);
     });
 
@@ -112,16 +114,19 @@ export const authMiddleware = createMiddleware<{
         const jwt = c.get('jwt');
         const db = c.get('db');
 
-        const token = await profileAsync(c, "auth_token", () => {
+        const bearerToken = await profileAsync(c, "auth_token", () => {
             const authHeader = c.req.header('authorization');
             if (authHeader && authHeader.startsWith('Bearer ')) {
                 return authHeader.substring(7);
             }
+            return undefined;
+        });
+        const cookieToken = await profileAsync(c, "auth_cookie_token", () => {
             return getCookie(c, 'token');
         });
 
-        if (token && jwt) {
-            const profile = await profileAsync(c, "auth_verify", () => jwt.verify(token));
+        if (bearerToken && jwt) {
+            const profile = await profileAsync(c, "auth_verify", () => jwt.verify(bearerToken));
             if (profile) {
                 const { users } = await import("../db/schema");
                 const user = await profileAsync(c, "auth_user_lookup", () => db.query.users.findFirst({
@@ -132,10 +137,71 @@ export const authMiddleware = createMiddleware<{
                     c.set('uid', user.id);
                     c.set('username', user.username);
                     c.set('admin', user.permission === 1);
+                    c.set('authType', 'jwt');
+                    return;
+                }
+            }
+
+            const { apiKeys } = await import("../db/schema");
+            const { hashApiKey, parseApiKeyScopes } = await import("../utils/api-keys");
+            const now = new Date();
+            const keyHash = await profileAsync(c, "auth_api_key_hash", () => hashApiKey(bearerToken));
+            const apiKey = await profileAsync(c, "auth_api_key_lookup", () => db.query.apiKeys.findFirst({
+                where: and(
+                    eq(apiKeys.keyHash, keyHash),
+                    isNull(apiKeys.revokedAt),
+                    or(isNull(apiKeys.expiresAt), gt(apiKeys.expiresAt, now)),
+                ),
+                with: {
+                    createdByUser: true,
+                },
+            }));
+
+            if (apiKey?.createdByUser) {
+                await profileAsync(c, "auth_api_key_touch", () => db.update(apiKeys)
+                    .set({ lastUsedAt: now, updatedAt: now })
+                    .where(eq(apiKeys.id, apiKey.id)));
+
+                const scopes = parseApiKeyScopes(apiKey.scopes);
+                c.set('uid', apiKey.createdByUser.id);
+                c.set('username', apiKey.createdByUser.username);
+                c.set('admin', apiKey.createdByUser.permission === 1);
+                c.set('authType', 'api-key');
+                c.set('apiKeyScopes', scopes);
+                return;
+            }
+        }
+
+        if (cookieToken && jwt) {
+            const profile = await profileAsync(c, "auth_cookie_verify", () => jwt.verify(cookieToken));
+            if (profile) {
+                const { users } = await import("../db/schema");
+                const user = await profileAsync(c, "auth_cookie_user_lookup", () => db.query.users.findFirst({
+                    where: eq(users.id, profile.id)
+                }));
+
+                if (user) {
+                    c.set('uid', user.id);
+                    c.set('username', user.username);
+                    c.set('admin', user.permission === 1);
+                    c.set('authType', 'jwt');
                 }
             }
         }
     });
+
+    if (c.get("authType") === "api-key") {
+        const { getRequiredApiKeyScope, hasApiKeyScope } = await import("../utils/api-keys");
+        const requiredScope = getRequiredApiKeyScope(c.req.method, c.req.path);
+
+        if (!requiredScope) {
+            return c.text("API key does not have access to this route", 403);
+        }
+
+        if (!hasApiKeyScope(c.get("apiKeyScopes"), requiredScope)) {
+            return c.text("API key does not have the required scope", 403);
+        }
+    }
 
     await next();
 });

--- a/server/src/core/hono-types.ts
+++ b/server/src/core/hono-types.ts
@@ -38,6 +38,8 @@ export interface Variables {
     uid?: number;
     admin: boolean;
     username?: string;
+    authType?: "jwt" | "api-key";
+    apiKeyScopes?: string[];
     env: Env;
 }
 

--- a/server/src/core/register-routes.ts
+++ b/server/src/core/register-routes.ts
@@ -1,4 +1,5 @@
 import type { RinApp } from "./app-types";
+import { ApiKeyService } from "../services/api-keys";
 import { PasswordAuthService } from "../services/auth";
 import { CommentService } from "../services/comments";
 import { ConfigService } from "../services/config";
@@ -25,6 +26,7 @@ export function registerRoutes(app: RinApp) {
   app.route("/moments", MomentsService());
   app.route("/user", UserService());
   app.route("/auth", PasswordAuthService());
+  app.route("/api-keys", ApiKeyService());
   app.route("/config", ConfigService());
   app.route("/", RSSService());
   app.route("/favicon", FaviconService());

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -73,6 +73,20 @@ export const users = sqliteTable("users", {
     updatedAt: updated_at,
 });
 
+export const apiKeys = sqliteTable("api_keys", {
+    id: integer("id").primaryKey(),
+    name: text("name").notNull(),
+    keyPrefix: text("key_prefix").notNull(),
+    keyHash: text("key_hash").notNull().unique(),
+    scopes: text("scopes").default("[]").notNull(),
+    createdByUid: integer("created_by_uid").references(() => users.id, { onDelete: 'cascade' }).notNull(),
+    lastUsedAt: integer("last_used_at", { mode: 'timestamp' }),
+    expiresAt: integer("expires_at", { mode: 'timestamp' }),
+    revokedAt: integer("revoked_at", { mode: 'timestamp' }),
+    createdAt: created_at,
+    updatedAt: updated_at,
+});
+
 export const comments = sqliteTable("comments", {
     id: integer("id").primaryKey(),
     feedId: integer("feed_id").references(() => feeds.id, { onDelete: 'cascade' }).notNull(),
@@ -131,6 +145,13 @@ export const commentsRelations = relations(comments, ({ one }) => ({
     }),
     user: one(users, {
         fields: [comments.userId],
+        references: [users.id],
+    }),
+}));
+
+export const apiKeysRelations = relations(apiKeys, ({ one }) => ({
+    createdByUser: one(users, {
+        fields: [apiKeys.createdByUid],
         references: [users.id],
     }),
 }));

--- a/server/src/services/__tests__/api-keys.test.ts
+++ b/server/src/services/__tests__/api-keys.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Database } from "bun:sqlite";
+import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import { authMiddleware } from "../../core/hono-middleware";
+import type { Variables } from "../../core/hono-types";
+import type { ApiKeyListResponse, CreateApiKeyResponse } from "@rin/api";
+import { FeedService } from "../feed";
+import { ApiKeyService } from "../api-keys";
+import { ConfigService } from "../config";
+import { UserService } from "../user";
+import { hashApiKey } from "../../utils/api-keys";
+import {
+    TestCacheImpl,
+    cleanupTestDB,
+    createMockDB,
+    createMockEnv,
+} from "../../../tests/fixtures";
+
+describe("ApiKeyService", () => {
+    let db: any;
+    let sqlite: Database;
+    let env: Env;
+    let app: Hono<{ Bindings: Env; Variables: Variables }>;
+
+    beforeEach(() => {
+        const mockDB = createMockDB();
+        db = mockDB.db;
+        sqlite = mockDB.sqlite;
+        env = createMockEnv({
+            ADMIN_USERNAME: "admin",
+            ADMIN_PASSWORD: "admin123",
+        });
+
+        sqlite.exec(`
+            INSERT INTO users (id, username, avatar, openid, password, permission)
+            VALUES (1, 'admin', '', 'admin', 'hashed', 1)
+        `);
+
+        app = new Hono<{ Bindings: Env; Variables: Variables }>();
+        app.use(createMiddleware(async (c, next) => {
+            c.set("db", db);
+            c.set("env", env);
+            c.set("admin", true);
+            c.set("uid", 1);
+            c.set("username", "admin");
+            c.set("authType", "jwt");
+            await next();
+        }));
+        app.route("/api-keys", ApiKeyService());
+    });
+
+    afterEach(() => {
+        cleanupTestDB(sqlite);
+    });
+
+    it("creates, lists, and revokes an API key", async () => {
+        const createResponse = await app.request("/api-keys", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+            },
+            body: JSON.stringify({
+                name: "Agent Writer",
+            }),
+        }, env);
+        expect(createResponse.status).toBe(200);
+        const created = await createResponse.json() as CreateApiKeyResponse;
+        expect(created.secret.startsWith("rin_")).toBe(true);
+        expect(created.apiKey.name).toBe("Agent Writer");
+        expect(created.apiKey.scopes).toContain("content:write");
+
+        const listResponse = await app.request("/api-keys", { method: "GET" }, env);
+        expect(listResponse.status).toBe(200);
+        const listed = await listResponse.json() as ApiKeyListResponse;
+        expect(listed.items).toHaveLength(1);
+        expect(listed.items[0].keyPrefix).toBe(created.apiKey.keyPrefix);
+        expect(listed.items[0].revokedAt).toBeNull();
+
+        const revokeResponse = await app.request(`/api-keys/${created.apiKey.id}/revoke`, {
+            method: "POST",
+        }, env);
+        expect(revokeResponse.status).toBe(200);
+
+        const afterRevokeResponse = await app.request("/api-keys", { method: "GET" }, env);
+        const afterRevoke = await afterRevokeResponse.json() as ApiKeyListResponse;
+        expect(afterRevoke.items[0].revokedAt).not.toBeNull();
+    });
+});
+
+describe("API key auth middleware", () => {
+    let db: any;
+    let sqlite: Database;
+    let env: Env;
+    let app: Hono<{ Bindings: Env; Variables: Variables }>;
+
+    beforeEach(async () => {
+        const mockDB = createMockDB();
+        db = mockDB.db;
+        sqlite = mockDB.sqlite;
+        env = createMockEnv({
+            ADMIN_USERNAME: "admin",
+            ADMIN_PASSWORD: "admin123",
+        });
+
+        sqlite.exec(`
+            INSERT INTO users (id, username, avatar, openid, password, permission)
+            VALUES (1, 'admin', '', 'admin', 'hashed', 1)
+        `);
+
+        const secret = "rin_test_agent_key";
+        sqlite.exec(`
+            INSERT INTO api_keys (id, name, key_prefix, key_hash, scopes, created_by_uid)
+            VALUES (
+                1,
+                'Agent Writer',
+                'rin_test_age',
+                '${await hashApiKey(secret)}',
+                '["content:read","content:write","moments:write","media:write"]',
+                1
+            )
+        `);
+
+        const cache = new TestCacheImpl();
+        const clientConfig = new TestCacheImpl();
+        const serverConfig = new TestCacheImpl();
+
+        app = new Hono<{ Bindings: Env; Variables: Variables }>();
+        app.use(createMiddleware(async (c, next) => {
+            c.set("db", db);
+            c.set("env", env);
+            c.set("cache", cache);
+            c.set("clientConfig", clientConfig);
+            c.set("serverConfig", serverConfig);
+            c.set("jwt", {
+                sign: async (payload: any) => `mock_token_${payload.id}`,
+                verify: async (token: string) => {
+                    const match = token.match(/mock_token_(\d+)/);
+                    return match ? { id: Number(match[1]) } : null;
+                },
+            });
+            c.set("admin", false);
+            await next();
+        }));
+        app.use("*", authMiddleware);
+        app.route("/feed", FeedService());
+        app.route("/config", ConfigService());
+        app.route("/user", UserService());
+    });
+
+    afterEach(() => {
+        cleanupTestDB(sqlite);
+    });
+
+    it("allows documented content routes with a bearer API key and blocks other routes", async () => {
+        const createFeedResponse = await app.request("/feed", {
+            method: "POST",
+            headers: {
+                authorization: "Bearer rin_test_agent_key",
+                "content-type": "application/json",
+            },
+            body: JSON.stringify({
+                title: "Agent-created post",
+                content: "Hello from an external agent.",
+                summary: "Summary",
+                alias: "agent-created-post",
+                draft: false,
+                listed: true,
+                tags: [],
+            }),
+        }, env);
+
+        expect(createFeedResponse.status).toBe(200);
+        const createdFeed = await createFeedResponse.json() as { insertedId?: number };
+        expect(createdFeed.insertedId).toBeDefined();
+
+        const configResponse = await app.request("/config", {
+            method: "GET",
+            headers: {
+                authorization: "Bearer rin_test_agent_key",
+            },
+        }, env);
+        expect(configResponse.status).toBe(403);
+
+        const userProfileResponse = await app.request("/user/profile", {
+            method: "GET",
+            headers: {
+                authorization: "Bearer rin_test_agent_key",
+            },
+        }, env);
+        expect(userProfileResponse.status).toBe(403);
+
+        const keyRecord = sqlite.prepare("SELECT last_used_at FROM api_keys WHERE id = 1").get() as { last_used_at: number | null };
+        expect(keyRecord.last_used_at).not.toBeNull();
+    });
+
+    it("enforces stored API key scopes on allowed routes", async () => {
+        const readOnlySecret = "rin_test_read_only_key";
+        sqlite.exec(`
+            INSERT INTO api_keys (id, name, key_prefix, key_hash, scopes, created_by_uid)
+            VALUES (
+                2,
+                'Read Only Agent',
+                'rin_test_rea',
+                '${await hashApiKey(readOnlySecret)}',
+                '["content:read"]',
+                1
+            )
+        `);
+
+        const createFeedResponse = await app.request("/feed", {
+            method: "POST",
+            headers: {
+                authorization: `Bearer ${readOnlySecret}`,
+                "content-type": "application/json",
+            },
+            body: JSON.stringify({
+                title: "Read-only should fail",
+                content: "Blocked write",
+                summary: "Blocked write",
+                alias: "read-only-should-fail",
+                draft: true,
+                listed: false,
+                tags: [],
+            }),
+        }, env);
+
+        expect(createFeedResponse.status).toBe(403);
+    });
+});

--- a/server/src/services/api-keys.ts
+++ b/server/src/services/api-keys.ts
@@ -1,0 +1,156 @@
+import { desc, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import type { AppContext } from "../core/hono-types";
+import { apiKeys } from "../db/schema";
+import { profileAsync } from "../core/server-timing";
+import { generateApiKeySecret, getApiKeyPrefix, hashApiKey, parseApiKeyScopes } from "../utils/api-keys";
+
+const DEFAULT_AGENT_SCOPES = [
+    "content:read",
+    "content:write",
+    "moments:write",
+    "media:write",
+];
+
+function requireInteractiveAdmin(c: AppContext) {
+    if (!c.get("admin")) {
+        return c.text("Unauthorized", 401);
+    }
+
+    if (c.get("authType") === "api-key") {
+        return c.text("API keys cannot manage API keys", 403);
+    }
+
+    return null;
+}
+
+function serializeApiKeyRecord(record: typeof apiKeys.$inferSelect & {
+    createdByUser?: {
+        id: number;
+        username: string;
+    } | null;
+}) {
+    return {
+        id: record.id,
+        name: record.name,
+        keyPrefix: record.keyPrefix,
+        scopes: parseApiKeyScopes(record.scopes),
+        createdAt: record.createdAt.toISOString(),
+        updatedAt: record.updatedAt.toISOString(),
+        lastUsedAt: record.lastUsedAt?.toISOString() ?? null,
+        expiresAt: record.expiresAt?.toISOString() ?? null,
+        revokedAt: record.revokedAt?.toISOString() ?? null,
+        createdByUser: record.createdByUser
+            ? {
+                id: record.createdByUser.id,
+                username: record.createdByUser.username,
+            }
+            : null,
+    };
+}
+
+export function ApiKeyService(): Hono {
+    const app = new Hono();
+
+    app.get("/", async (c: AppContext) => {
+        const unauthorized = requireInteractiveAdmin(c);
+        if (unauthorized) {
+            return unauthorized;
+        }
+
+        const db = c.get("db");
+        const items = await profileAsync(c, "api_keys_list", () => db.query.apiKeys.findMany({
+            with: {
+                createdByUser: {
+                    columns: {
+                        id: true,
+                        username: true,
+                    },
+                },
+            },
+            orderBy: [desc(apiKeys.createdAt)],
+        }));
+
+        return c.json({
+            items: items.map((item) => serializeApiKeyRecord(item)),
+        });
+    });
+
+    app.post("/", async (c: AppContext) => {
+        const unauthorized = requireInteractiveAdmin(c);
+        if (unauthorized) {
+            return unauthorized;
+        }
+
+        const db = c.get("db");
+        const uid = c.get("uid");
+        const body = await profileAsync(c, "api_keys_create_parse", () => c.req.json()) as {
+            name?: string;
+            expiresAt?: string | null;
+        };
+        const name = body.name?.trim();
+
+        if (!uid) {
+            return c.text("Unauthorized", 401);
+        }
+
+        if (!name) {
+            return c.text("Name is required", 400);
+        }
+
+        const expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
+        if (expiresAt && Number.isNaN(expiresAt.getTime())) {
+            return c.text("Invalid expiration date", 400);
+        }
+
+        const secret = generateApiKeySecret();
+        const now = new Date();
+        const result = await profileAsync(c, "api_keys_create_insert", async () => {
+            return db.insert(apiKeys).values({
+                name,
+                keyPrefix: getApiKeyPrefix(secret),
+                keyHash: await hashApiKey(secret),
+                scopes: JSON.stringify(DEFAULT_AGENT_SCOPES),
+                createdByUid: uid,
+                expiresAt: expiresAt ?? undefined,
+                createdAt: now,
+                updatedAt: now,
+            }).returning();
+        });
+
+        const created = result[0];
+        if (!created) {
+            return c.text("Failed to create API key", 500);
+        }
+
+        return c.json({
+            secret,
+            apiKey: serializeApiKeyRecord(created),
+        });
+    });
+
+    app.post("/:id/revoke", async (c: AppContext) => {
+        const unauthorized = requireInteractiveAdmin(c);
+        if (unauthorized) {
+            return unauthorized;
+        }
+
+        const db = c.get("db");
+        const id = Number(c.req.param("id"));
+        if (!Number.isInteger(id) || id <= 0) {
+            return c.text("Invalid API key id", 400);
+        }
+
+        const now = new Date();
+        await profileAsync(c, "api_keys_revoke", () => db.update(apiKeys)
+            .set({
+                revokedAt: now,
+                updatedAt: now,
+            })
+            .where(eq(apiKeys.id, id)));
+
+        return c.json({ success: true });
+    });
+
+    return app;
+}

--- a/server/src/utils/api-keys.ts
+++ b/server/src/utils/api-keys.ts
@@ -1,0 +1,64 @@
+function bytesToHex(buffer: ArrayBuffer) {
+    return Array.from(new Uint8Array(buffer))
+        .map((value) => value.toString(16).padStart(2, "0"))
+        .join("");
+}
+
+type ApiKeyRouteRule = {
+    method: string;
+    pattern: RegExp;
+    scope: string;
+};
+
+const API_KEY_ROUTE_RULES: ApiKeyRouteRule[] = [
+    { method: "GET", pattern: /^\/feed(?:\/timeline)?$/, scope: "content:read" },
+    { method: "GET", pattern: /^\/feed\/[^/]+$/, scope: "content:read" },
+    { method: "POST", pattern: /^\/feed$/, scope: "content:write" },
+    { method: "POST", pattern: /^\/feed\/[^/]+$/, scope: "content:write" },
+    { method: "DELETE", pattern: /^\/feed\/[^/]+$/, scope: "content:write" },
+    { method: "POST", pattern: /^\/moments$/, scope: "moments:write" },
+    { method: "POST", pattern: /^\/storage$/, scope: "media:write" },
+];
+
+export async function hashApiKey(secret: string): Promise<string> {
+    const encoder = new TextEncoder();
+    return bytesToHex(await crypto.subtle.digest("SHA-256", encoder.encode(secret)));
+}
+
+export function generateApiKeySecret() {
+    const bytes = crypto.getRandomValues(new Uint8Array(24));
+    return `rin_${bytesToHex(bytes.buffer)}`;
+}
+
+export function getApiKeyPrefix(secret: string) {
+    return secret.slice(0, 12);
+}
+
+export function parseApiKeyScopes(value: string | null | undefined) {
+    if (!value) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed.filter((scope): scope is string => typeof scope === "string") : [];
+    } catch {
+        return [];
+    }
+}
+
+export function getRequiredApiKeyScope(method: string, path: string) {
+    const normalizedMethod = method.toUpperCase();
+
+    for (const rule of API_KEY_ROUTE_RULES) {
+        if (rule.method === normalizedMethod && rule.pattern.test(path)) {
+            return rule.scope;
+        }
+    }
+
+    return null;
+}
+
+export function hasApiKeyScope(scopes: string[] | undefined, requiredScope: string) {
+    return Array.isArray(scopes) && scopes.includes(requiredScope);
+}

--- a/server/tests/fixtures/index.ts
+++ b/server/tests/fixtures/index.ts
@@ -36,6 +36,21 @@ export function createMockDB() {
             updated_at INTEGER DEFAULT (unixepoch())
         );
 
+        CREATE TABLE IF NOT EXISTS api_keys (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            key_prefix TEXT NOT NULL,
+            key_hash TEXT NOT NULL UNIQUE,
+            scopes TEXT DEFAULT '[]' NOT NULL,
+            created_by_uid INTEGER NOT NULL,
+            last_used_at INTEGER,
+            expires_at INTEGER,
+            revoked_at INTEGER,
+            created_at INTEGER DEFAULT (unixepoch()),
+            updated_at INTEGER DEFAULT (unixepoch()),
+            FOREIGN KEY (created_by_uid) REFERENCES users(id) ON DELETE CASCADE
+        );
+
         -- Feeds table
         CREATE TABLE IF NOT EXISTS feeds (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary

- add admin-managed API keys for external agent workflows
- enforce API-key route scopes for content, moments, and media operations
- add an admin API Keys page plus a bundled Rin skill for agent setup

## What's included

- `/api/api-keys` management endpoints for interactive admins
- bearer API-key auth with route-to-scope enforcement
- admin UI entry + page for creating, listing, and revoking keys
- built-in skill published at `/skills/rin-agent/SKILL.md`

## Checks

- `bunx turbo check` ✅
