### PR TITLE
fix(deploy): improve URL extraction logic in deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -224,7 +224,19 @@ jobs:
           else
             bun run deploy --preview | tee deploy_output.log
           fi
-          URL=$(grep -oP 'App URL: \Khttps://[^\s]+' deploy_output.log || echo "https://${WORKER_NAME}.${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.workers.dev")
+          URL="$(grep -oP 'App URL:\s*\Khttps://[^\s]+' deploy_output.log | tail -n 1 || true)"
+          if [[ -z "$URL" ]]; then
+            URL="$(awk '
+              /^Deployed .* triggers/ { in_targets = 1; next }
+              in_targets && match($0, /https?:\/\/[^[:space:]]+/) { print substr($0, RSTART, RLENGTH); exit }
+            ' deploy_output.log)"
+          fi
+          if [[ -z "$URL" ]]; then
+            echo "❌ Unable to determine deployment URL from deploy output."
+            grep -E 'App URL:|Deployed .* triggers|https?://' deploy_output.log || true
+            exit 1
+          fi
+          echo "Resolved deployment URL: ${URL}"
           echo "url=${URL}" >> $GITHUB_OUTPUT
 
       - name: Comment on PR


### PR DESCRIPTION
This pull request improves the deployment workflow by making the extraction of the deployment URL from the deploy output more robust. The changes add fallback mechanisms to ensure the URL is correctly determined, and provide clearer error handling if the URL cannot be found.

Deployment workflow improvements:

* Enhanced the logic for extracting the deployment URL in `.github/workflows/deploy.yml` by adding a fallback using `awk` to search for URLs in the output, and added error handling with a descriptive message if the URL cannot be determined.