### PR TITLE
feat: add guest comment support

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -99,7 +99,11 @@
     },
     "submit": "Submit Comment",
     "success": "Comment successful",
-    "title": "Comment"
+    "title": "Comment",
+    "guest_name_required": "Guest name is required",
+    "guest_name_placeholder": "Name (required)",
+    "guest_email_placeholder": "Email (optional)",
+    "guest_website_placeholder": "Website (optional)"
   },
   "comparison": "Comparison",
   "confirm": "Confirm",
@@ -281,47 +285,47 @@
         "success": "Favicon update was successful"
       }
     },
-  "footer": {
-    "desc": "Set the footer content of the site (HTML)",
-    "title": "Footer"
-  },
-  "webhook": {
-    "title": "Webhook",
-    "url": {
-      "title": "Webhook URL",
-      "desc": "Set the webhook endpoint used for comment and friend-link notifications. Template variables are supported here too, which is useful for GET query strings."
+    "footer": {
+      "desc": "Set the footer content of the site (HTML)",
+      "title": "Footer"
     },
-    "method": {
-      "title": "Webhook Method",
-      "desc": "Set the HTTP method used for webhook requests, such as POST, PUT, or PATCH"
+    "webhook": {
+      "title": "Webhook",
+      "url": {
+        "title": "Webhook URL",
+        "desc": "Set the webhook endpoint used for comment and friend-link notifications. Template variables are supported here too, which is useful for GET query strings."
+      },
+      "method": {
+        "title": "Webhook Method",
+        "desc": "Set the HTTP method used for webhook requests, such as POST, PUT, or PATCH"
+      },
+      "content_type": {
+        "title": "Webhook Content-Type",
+        "desc": "Set the Content-Type header sent with webhook requests, for example application/json or text/plain"
+      },
+      "headers": {
+        "title": "Webhook Headers",
+        "desc": "Customize webhook headers as a JSON object template. Available variables are the same as the body template.",
+        "label": "Webhook headers JSON"
+      },
+      "body_template": {
+        "title": "Webhook Body Template",
+        "desc": "Customize the outgoing webhook payload. Available variables: {{event}}, {{message}}, {{title}}, {{url}}, {{username}}, {{content}}, {{description}}.",
+        "label": "Webhook body template"
+      },
+      "test": {
+        "title": "Send Test Webhook",
+        "desc": "Send a test request with the current webhook settings. Unsaved values in this page are used directly.",
+        "button": "Send Test",
+        "sending": "Sending...",
+        "placeholder": "Optional test message. Leave empty to use the default test payload.",
+        "success": "Webhook test sent successfully",
+        "failed": "Webhook test failed"
+      }
     },
-    "content_type": {
-      "title": "Webhook Content-Type",
-      "desc": "Set the Content-Type header sent with webhook requests, for example application/json or text/plain"
+    "maintenance": {
+      "title": "Maintenance"
     },
-    "headers": {
-      "title": "Webhook Headers",
-      "desc": "Customize webhook headers as a JSON object template. Available variables are the same as the body template.",
-      "label": "Webhook headers JSON"
-    },
-    "body_template": {
-      "title": "Webhook Body Template",
-      "desc": "Customize the outgoing webhook payload. Available variables: {{event}}, {{message}}, {{title}}, {{url}}, {{username}}, {{content}}, {{description}}.",
-      "label": "Webhook body template"
-    },
-    "test": {
-      "title": "Send Test Webhook",
-      "desc": "Send a test request with the current webhook settings. Unsaved values in this page are used directly.",
-      "button": "Send Test",
-      "sending": "Sending...",
-      "placeholder": "Optional test message. Leave empty to use the default test payload.",
-      "success": "Webhook test sent successfully",
-      "failed": "Webhook test failed"
-    }
-  },
-  "maintenance": {
-    "title": "Maintenance"
-  },
     "friend": {
       "apply": {
         "desc": "Allow other users to apply for friend links (requires review)",
@@ -574,33 +578,33 @@
           "summary": "login.enabled is disabled.",
           "suggestion": "Enable login in settings if this instance needs interactive admin access."
         },
-      "missing": {
-        "impact": "Users can see the login entry but no working login method is configured.",
-        "summary": "Neither GitHub OAuth nor password login is configured.",
-        "suggestion": "Configure RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET or ADMIN_USERNAME/ADMIN_PASSWORD."
-      },
-      "default_password": {
-        "impact": "The admin account is still using the default username and password, which is a critical security risk.",
-        "summary": "ADMIN_USERNAME/ADMIN_PASSWORD are still set to admin / admin123.",
-        "suggestion": "Change the default username or password immediately before exposing the site."
-      },
-      "oauth_missing": {
-        "impact": "Only the local password account can sign in. Other users cannot log in and comment through OAuth.",
-        "summary": "GitHub OAuth is not configured.",
-        "suggestion": "Configure RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET if you expect other users to log in."
-      },
-      "ready": {
-        "impact": "Admin sign-in is available.",
-        "summary": "OAuth login is configured and the current password login configuration is not using the default credentials.",
-        "suggestion": "No action required."
-      },
-      "details": {
-        "github_configured": "GitHub OAuth: configured",
-        "github_missing": "GitHub OAuth: missing",
-        "password_configured": "Password login: configured",
-        "password_missing": "Password login: missing",
-        "password_default": "Password login: using default credentials"
-      }
+        "missing": {
+          "impact": "Users can see the login entry but no working login method is configured.",
+          "summary": "Neither GitHub OAuth nor password login is configured.",
+          "suggestion": "Configure RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET or ADMIN_USERNAME/ADMIN_PASSWORD."
+        },
+        "default_password": {
+          "impact": "The admin account is still using the default username and password, which is a critical security risk.",
+          "summary": "ADMIN_USERNAME/ADMIN_PASSWORD are still set to admin / admin123.",
+          "suggestion": "Change the default username or password immediately before exposing the site."
+        },
+        "oauth_missing": {
+          "impact": "Only the local password account can sign in. Other users cannot log in and comment through OAuth.",
+          "summary": "GitHub OAuth is not configured.",
+          "suggestion": "Configure RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET if you expect other users to log in."
+        },
+        "ready": {
+          "impact": "Admin sign-in is available.",
+          "summary": "OAuth login is configured and the current password login configuration is not using the default credentials.",
+          "suggestion": "No action required."
+        },
+        "details": {
+          "github_configured": "GitHub OAuth: configured",
+          "github_missing": "GitHub OAuth: missing",
+          "password_configured": "Password login: configured",
+          "password_missing": "Password login: missing",
+          "password_default": "Password login: using default credentials"
+        }
       },
       "storage": {
         "title": "Object storage",
@@ -719,5 +723,6 @@
   },
   "sort_latest": "Latest",
   "sort_popular": "Popular",
-  "total_tags": "Total {{count}} tags"
+  "total_tags": "Total {{count}} tags",
+  "anonymous": "Anonymous"
 }

--- a/client/public/locales/ja/translation.json
+++ b/client/public/locales/ja/translation.json
@@ -99,7 +99,11 @@
     },
     "submit": "コメントを投稿",
     "success": "コメントに成功しました",
-    "title": "コメント"
+    "title": "コメント",
+    "guest_name_required": "ゲスト名は必須です",
+    "guest_name_placeholder": "名前（必須）",
+    "guest_email_placeholder": "メール（任意）",
+    "guest_website_placeholder": "ウェブサイト（任意）"
   },
   "comparison": "対比",
   "confirm": "確認",
@@ -272,47 +276,47 @@
         "success": "ファビコンの更新が成功しました"
       }
     },
-  "footer": {
-    "desc": "サイトのフッターコンテンツを設定する（HTML）",
-    "title": "フッター"
-  },
-  "webhook": {
-    "title": "Webhook",
-    "url": {
-      "title": "Webhook URL",
-      "desc": "コメント通知と友達リンク通知に使う webhook URL を設定します。ここでもテンプレート変数が使えるので、GET の query string にも利用できます。"
+    "footer": {
+      "desc": "サイトのフッターコンテンツを設定する（HTML）",
+      "title": "フッター"
     },
-    "method": {
-      "title": "Webhook Method",
-      "desc": "webhook リクエストで使う HTTP Method を設定します。GET、POST、PUT、PATCH などに対応します。"
+    "webhook": {
+      "title": "Webhook",
+      "url": {
+        "title": "Webhook URL",
+        "desc": "コメント通知と友達リンク通知に使う webhook URL を設定します。ここでもテンプレート変数が使えるので、GET の query string にも利用できます。"
+      },
+      "method": {
+        "title": "Webhook Method",
+        "desc": "webhook リクエストで使う HTTP Method を設定します。GET、POST、PUT、PATCH などに対応します。"
+      },
+      "content_type": {
+        "title": "Webhook Content-Type",
+        "desc": "Webhook リクエスト送信時の Content-Type を設定します。例: application/json, text/plain"
+      },
+      "headers": {
+        "title": "Webhook Headers",
+        "desc": "JSON テンプレートで webhook ヘッダーをカスタマイズします。使える変数は本文テンプレートと同じです。",
+        "label": "Webhook headers JSON"
+      },
+      "body_template": {
+        "title": "Webhook ボディテンプレート",
+        "desc": "送信する webhook リクエスト本文をカスタマイズします。使用可能変数: {{event}}, {{message}}, {{title}}, {{url}}, {{username}}, {{content}}, {{description}}。",
+        "label": "Webhook ボディテンプレート"
+      },
+      "test": {
+        "title": "テスト Webhook を送信",
+        "desc": "このページ上の現在の webhook 設定でテストリクエストを送信します。未保存の値もそのまま使われます。",
+        "button": "テスト送信",
+        "sending": "送信中...",
+        "placeholder": "任意のテストメッセージ。空の場合は既定のテスト payload を使います。",
+        "success": "Webhook テストの送信に成功しました",
+        "failed": "Webhook テストの送信に失敗しました"
+      }
     },
-    "content_type": {
-      "title": "Webhook Content-Type",
-      "desc": "Webhook リクエスト送信時の Content-Type を設定します。例: application/json, text/plain"
+    "maintenance": {
+      "title": "メンテナンス"
     },
-    "headers": {
-      "title": "Webhook Headers",
-      "desc": "JSON テンプレートで webhook ヘッダーをカスタマイズします。使える変数は本文テンプレートと同じです。",
-      "label": "Webhook headers JSON"
-    },
-    "body_template": {
-      "title": "Webhook ボディテンプレート",
-      "desc": "送信する webhook リクエスト本文をカスタマイズします。使用可能変数: {{event}}, {{message}}, {{title}}, {{url}}, {{username}}, {{content}}, {{description}}。",
-      "label": "Webhook ボディテンプレート"
-    },
-    "test": {
-      "title": "テスト Webhook を送信",
-      "desc": "このページ上の現在の webhook 設定でテストリクエストを送信します。未保存の値もそのまま使われます。",
-      "button": "テスト送信",
-      "sending": "送信中...",
-      "placeholder": "任意のテストメッセージ。空の場合は既定のテスト payload を使います。",
-      "success": "Webhook テストの送信に成功しました",
-      "failed": "Webhook テストの送信に失敗しました"
-    }
-  },
-  "maintenance": {
-    "title": "メンテナンス"
-  },
     "friend": {
       "apply": {
         "desc": "他のユーザーが友人リンクを申請できるようにする（審査が必要）",
@@ -565,33 +569,33 @@
           "summary": "login.enabled が無効です。",
           "suggestion": "このインスタンスで対話的な管理アクセスが必要なら、設定でログインを有効にしてください。"
         },
-      "missing": {
-        "impact": "ログイン入口は表示されますが、利用可能なログイン方法がありません。",
-        "summary": "GitHub OAuth とパスワードログインのどちらも設定されていません。",
-        "suggestion": "RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET または ADMIN_USERNAME/ADMIN_PASSWORD を設定してください。"
-      },
-      "default_password": {
-        "impact": "管理者アカウントがまだ既定のユーザー名とパスワードを使っており、重大なセキュリティリスクです。",
-        "summary": "ADMIN_USERNAME/ADMIN_PASSWORD が admin / admin123 のままです。",
-        "suggestion": "サイトを公開する前に既定のユーザー名またはパスワードを直ちに変更してください。"
-      },
-      "oauth_missing": {
-        "impact": "現在はローカルのパスワードアカウントしか使えず、他のユーザーは OAuth でログインしてコメントできません。",
-        "summary": "GitHub OAuth が設定されていません。",
-        "suggestion": "他のユーザーにもログインを許可するなら、RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET を設定してください。"
-      },
-      "ready": {
-        "impact": "管理ログインが利用可能です。",
-        "summary": "OAuth ログインが設定済みで、現在のパスワードログインも既定の認証情報を使っていません。",
-        "suggestion": "対応は不要です。"
-      },
-      "details": {
-        "github_configured": "GitHub OAuth: 設定済み",
-        "github_missing": "GitHub OAuth: 未設定",
-        "password_configured": "パスワードログイン: 設定済み",
-        "password_missing": "パスワードログイン: 未設定",
-        "password_default": "パスワードログイン: 既定の認証情報を使用中"
-      }
+        "missing": {
+          "impact": "ログイン入口は表示されますが、利用可能なログイン方法がありません。",
+          "summary": "GitHub OAuth とパスワードログインのどちらも設定されていません。",
+          "suggestion": "RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET または ADMIN_USERNAME/ADMIN_PASSWORD を設定してください。"
+        },
+        "default_password": {
+          "impact": "管理者アカウントがまだ既定のユーザー名とパスワードを使っており、重大なセキュリティリスクです。",
+          "summary": "ADMIN_USERNAME/ADMIN_PASSWORD が admin / admin123 のままです。",
+          "suggestion": "サイトを公開する前に既定のユーザー名またはパスワードを直ちに変更してください。"
+        },
+        "oauth_missing": {
+          "impact": "現在はローカルのパスワードアカウントしか使えず、他のユーザーは OAuth でログインしてコメントできません。",
+          "summary": "GitHub OAuth が設定されていません。",
+          "suggestion": "他のユーザーにもログインを許可するなら、RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET を設定してください。"
+        },
+        "ready": {
+          "impact": "管理ログインが利用可能です。",
+          "summary": "OAuth ログインが設定済みで、現在のパスワードログインも既定の認証情報を使っていません。",
+          "suggestion": "対応は不要です。"
+        },
+        "details": {
+          "github_configured": "GitHub OAuth: 設定済み",
+          "github_missing": "GitHub OAuth: 未設定",
+          "password_configured": "パスワードログイン: 設定済み",
+          "password_missing": "パスワードログイン: 未設定",
+          "password_default": "パスワードログイン: 既定の認証情報を使用中"
+        }
       },
       "storage": {
         "title": "オブジェクトストレージ",
@@ -710,5 +714,6 @@
   },
   "sort_latest": "新着",
   "sort_popular": "人気",
-  "total_tags": "全 {{count}} 個のタグ"
+  "total_tags": "全 {{count}} 個のタグ",
+  "anonymous": "匿名"
 }

--- a/client/public/locales/zh-CN/translation.json
+++ b/client/public/locales/zh-CN/translation.json
@@ -99,7 +99,11 @@
     },
     "submit": "发表评论",
     "success": "评论成功",
-    "title": "评论"
+    "title": "评论",
+    "guest_name_required": "昵称不能为空",
+    "guest_name_placeholder": "昵称（必填）",
+    "guest_email_placeholder": "邮箱（可选）",
+    "guest_website_placeholder": "网站（可选）"
   },
   "comparison": "对比",
   "confirm": "确认",
@@ -281,47 +285,47 @@
         "success": "网站图标更新成功"
       }
     },
-  "footer": {
-    "desc": "设置显示于站点底部的内容（HTML）",
-    "title": "站点底部内容"
-  },
-  "webhook": {
-    "title": "Webhook",
-    "url": {
-      "title": "Webhook 地址",
-      "desc": "设置评论和友链通知使用的 webhook 地址。这里同样支持模板变量，适合 GET 场景拼接 query string。"
+    "footer": {
+      "desc": "设置显示于站点底部的内容（HTML）",
+      "title": "站点底部内容"
     },
-    "method": {
-      "title": "Webhook Method",
-      "desc": "设置 webhook 请求使用的 HTTP Method，例如 GET、POST、PUT 或 PATCH"
+    "webhook": {
+      "title": "Webhook",
+      "url": {
+        "title": "Webhook 地址",
+        "desc": "设置评论和友链通知使用的 webhook 地址。这里同样支持模板变量，适合 GET 场景拼接 query string。"
+      },
+      "method": {
+        "title": "Webhook Method",
+        "desc": "设置 webhook 请求使用的 HTTP Method，例如 GET、POST、PUT 或 PATCH"
+      },
+      "content_type": {
+        "title": "Webhook Content-Type",
+        "desc": "设置 webhook 请求发送时使用的 Content-Type，例如 application/json 或 text/plain"
+      },
+      "headers": {
+        "title": "Webhook 请求头",
+        "desc": "以 JSON 模板自定义 webhook 请求头。可用变量与请求体模板一致。",
+        "label": "Webhook 请求头 JSON"
+      },
+      "body_template": {
+        "title": "Webhook 请求体模板",
+        "desc": "自定义 webhook 发出的请求体。可用变量：{{event}}、{{message}}、{{title}}、{{url}}、{{username}}、{{content}}、{{description}}。",
+        "label": "Webhook 请求体模板"
+      },
+      "test": {
+        "title": "发送测试 Webhook",
+        "desc": "使用当前页面里的 webhook 设置发送一次测试请求。未保存的修改也会直接生效。",
+        "button": "发送测试",
+        "sending": "发送中...",
+        "placeholder": "可选的测试消息内容。留空时会使用默认测试负载。",
+        "success": "Webhook 测试发送成功",
+        "failed": "Webhook 测试发送失败"
+      }
     },
-    "content_type": {
-      "title": "Webhook Content-Type",
-      "desc": "设置 webhook 请求发送时使用的 Content-Type，例如 application/json 或 text/plain"
+    "maintenance": {
+      "title": "维护"
     },
-    "headers": {
-      "title": "Webhook 请求头",
-      "desc": "以 JSON 模板自定义 webhook 请求头。可用变量与请求体模板一致。",
-      "label": "Webhook 请求头 JSON"
-    },
-    "body_template": {
-      "title": "Webhook 请求体模板",
-      "desc": "自定义 webhook 发出的请求体。可用变量：{{event}}、{{message}}、{{title}}、{{url}}、{{username}}、{{content}}、{{description}}。",
-      "label": "Webhook 请求体模板"
-    },
-    "test": {
-      "title": "发送测试 Webhook",
-      "desc": "使用当前页面里的 webhook 设置发送一次测试请求。未保存的修改也会直接生效。",
-      "button": "发送测试",
-      "sending": "发送中...",
-      "placeholder": "可选的测试消息内容。留空时会使用默认测试负载。",
-      "success": "Webhook 测试发送成功",
-      "failed": "Webhook 测试发送失败"
-    }
-  },
-  "maintenance": {
-    "title": "维护"
-  },
     "friend": {
       "apply": {
         "desc": "允许其他用户申请友链（需审核）",
@@ -574,33 +578,33 @@
           "summary": "login.enabled 已关闭。",
           "suggestion": "如果此实例需要交互式后台访问，请在设置中启用登录。"
         },
-      "missing": {
-        "impact": "用户可以看到登录入口，但没有任何可用的登录方式。",
-        "summary": "GitHub OAuth 和密码登录都未配置。",
-        "suggestion": "请配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET 或 ADMIN_USERNAME/ADMIN_PASSWORD。"
-      },
-      "default_password": {
-        "impact": "管理员账号仍在使用默认用户名和密码，属于严重安全风险。",
-        "summary": "ADMIN_USERNAME/ADMIN_PASSWORD 仍然是 admin / admin123。",
-        "suggestion": "在公开站点前请立即修改默认用户名或密码。"
-      },
-      "oauth_missing": {
-        "impact": "当前只能使用本地密码账号登录，其他用户无法通过 OAuth 登录并评论。",
-        "summary": "GitHub OAuth 未配置。",
-        "suggestion": "如果希望其他用户登录，请配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET。"
-      },
-      "ready": {
-        "impact": "后台登录可用。",
-        "summary": "OAuth 登录已配置，且当前密码登录未使用默认凭据。",
-        "suggestion": "无需处理。"
-      },
-      "details": {
-        "github_configured": "GitHub OAuth：已配置",
-        "github_missing": "GitHub OAuth：未配置",
-        "password_configured": "密码登录：已配置",
-        "password_missing": "密码登录：未配置",
-        "password_default": "密码登录：使用默认凭据"
-      }
+        "missing": {
+          "impact": "用户可以看到登录入口，但没有任何可用的登录方式。",
+          "summary": "GitHub OAuth 和密码登录都未配置。",
+          "suggestion": "请配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET 或 ADMIN_USERNAME/ADMIN_PASSWORD。"
+        },
+        "default_password": {
+          "impact": "管理员账号仍在使用默认用户名和密码，属于严重安全风险。",
+          "summary": "ADMIN_USERNAME/ADMIN_PASSWORD 仍然是 admin / admin123。",
+          "suggestion": "在公开站点前请立即修改默认用户名或密码。"
+        },
+        "oauth_missing": {
+          "impact": "当前只能使用本地密码账号登录，其他用户无法通过 OAuth 登录并评论。",
+          "summary": "GitHub OAuth 未配置。",
+          "suggestion": "如果希望其他用户登录，请配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET。"
+        },
+        "ready": {
+          "impact": "后台登录可用。",
+          "summary": "OAuth 登录已配置，且当前密码登录未使用默认凭据。",
+          "suggestion": "无需处理。"
+        },
+        "details": {
+          "github_configured": "GitHub OAuth：已配置",
+          "github_missing": "GitHub OAuth：未配置",
+          "password_configured": "密码登录：已配置",
+          "password_missing": "密码登录：未配置",
+          "password_default": "密码登录：使用默认凭据"
+        }
       },
       "storage": {
         "title": "对象存储",
@@ -719,5 +723,6 @@
   },
   "sort_latest": "最新",
   "sort_popular": "热门",
-  "total_tags": "共 {{count}} 个标签"
+  "total_tags": "共 {{count}} 个标签",
+  "anonymous": "匿名"
 }

--- a/client/public/locales/zh-TW/translation.json
+++ b/client/public/locales/zh-TW/translation.json
@@ -99,7 +99,11 @@
     },
     "submit": "發表留言",
     "success": "留言成功",
-    "title": "留言"
+    "title": "留言",
+    "guest_name_required": "暱稱不能為空",
+    "guest_name_placeholder": "暱稱（必填）",
+    "guest_email_placeholder": "郵箱（可選）",
+    "guest_website_placeholder": "網站（可選）"
   },
   "comparison": "比較",
   "confirm": "確認",
@@ -169,7 +173,7 @@
   "listed": "列出在文章中",
   "load_more": "載入更多",
   "login": {
-    "error":{      
+    "error": {
       "empty": "請輸入用戶名和密碼",
       "failed": "登入失敗",
       "invalid": "用戶名或密碼錯誤",
@@ -281,47 +285,47 @@
         "success": "網站圖標更新成功"
       }
     },
-  "footer": {
-    "desc": "設定顯示於網站底部的內容（HTML）",
-    "title": "網站底部內容"
-  },
-  "webhook": {
-    "title": "Webhook",
-    "url": {
-      "title": "Webhook 位址",
-      "desc": "設定評論與友鏈通知使用的 webhook 位址。這裡同樣支援模板變數，適合在 GET 場景拼接 query string。"
+    "footer": {
+      "desc": "設定顯示於網站底部的內容（HTML）",
+      "title": "網站底部內容"
     },
-    "method": {
-      "title": "Webhook Method",
-      "desc": "設定 webhook 請求使用的 HTTP Method，例如 GET、POST、PUT 或 PATCH"
+    "webhook": {
+      "title": "Webhook",
+      "url": {
+        "title": "Webhook 位址",
+        "desc": "設定評論與友鏈通知使用的 webhook 位址。這裡同樣支援模板變數，適合在 GET 場景拼接 query string。"
+      },
+      "method": {
+        "title": "Webhook Method",
+        "desc": "設定 webhook 請求使用的 HTTP Method，例如 GET、POST、PUT 或 PATCH"
+      },
+      "content_type": {
+        "title": "Webhook Content-Type",
+        "desc": "設定 webhook 請求送出時使用的 Content-Type，例如 application/json 或 text/plain"
+      },
+      "headers": {
+        "title": "Webhook 請求標頭",
+        "desc": "以 JSON 模板自訂 webhook 請求標頭。可用變數與請求體模板一致。",
+        "label": "Webhook 請求標頭 JSON"
+      },
+      "body_template": {
+        "title": "Webhook 請求體模板",
+        "desc": "自訂 webhook 送出的請求體。可用變數：{{event}}、{{message}}、{{title}}、{{url}}、{{username}}、{{content}}、{{description}}。",
+        "label": "Webhook 請求體模板"
+      },
+      "test": {
+        "title": "發送測試 Webhook",
+        "desc": "使用目前頁面中的 webhook 設定發送一次測試請求。尚未儲存的修改也會直接生效。",
+        "button": "發送測試",
+        "sending": "發送中...",
+        "placeholder": "可選的測試訊息內容。留空時會使用預設測試負載。",
+        "success": "Webhook 測試發送成功",
+        "failed": "Webhook 測試發送失敗"
+      }
     },
-    "content_type": {
-      "title": "Webhook Content-Type",
-      "desc": "設定 webhook 請求送出時使用的 Content-Type，例如 application/json 或 text/plain"
+    "maintenance": {
+      "title": "維護"
     },
-    "headers": {
-      "title": "Webhook 請求標頭",
-      "desc": "以 JSON 模板自訂 webhook 請求標頭。可用變數與請求體模板一致。",
-      "label": "Webhook 請求標頭 JSON"
-    },
-    "body_template": {
-      "title": "Webhook 請求體模板",
-      "desc": "自訂 webhook 送出的請求體。可用變數：{{event}}、{{message}}、{{title}}、{{url}}、{{username}}、{{content}}、{{description}}。",
-      "label": "Webhook 請求體模板"
-    },
-    "test": {
-      "title": "發送測試 Webhook",
-      "desc": "使用目前頁面中的 webhook 設定發送一次測試請求。尚未儲存的修改也會直接生效。",
-      "button": "發送測試",
-      "sending": "發送中...",
-      "placeholder": "可選的測試訊息內容。留空時會使用預設測試負載。",
-      "success": "Webhook 測試發送成功",
-      "failed": "Webhook 測試發送失敗"
-    }
-  },
-  "maintenance": {
-    "title": "維護"
-  },
     "friend": {
       "apply": {
         "desc": "允許其他用戶申請友情連結（需審核）",
@@ -574,33 +578,33 @@
           "summary": "login.enabled 已關閉。",
           "suggestion": "如果此實例需要互動式後台存取，請在設定中啟用登入。"
         },
-      "missing": {
-        "impact": "使用者可以看到登入入口，但沒有任何可用的登入方式。",
-        "summary": "GitHub OAuth 和密碼登入都未配置。",
-        "suggestion": "請配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET 或 ADMIN_USERNAME/ADMIN_PASSWORD。"
-      },
-      "default_password": {
-        "impact": "管理員帳號仍在使用預設使用者名稱與密碼，屬於嚴重安全風險。",
-        "summary": "ADMIN_USERNAME/ADMIN_PASSWORD 仍然是 admin / admin123。",
-        "suggestion": "在公開網站之前請立即修改預設使用者名稱或密碼。"
-      },
-      "oauth_missing": {
-        "impact": "目前只能使用本地密碼帳號登入，其他使用者無法透過 OAuth 登入並留言。",
-        "summary": "GitHub OAuth 未配置。",
-        "suggestion": "如果希望其他使用者登入，請配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET。"
-      },
-      "ready": {
-        "impact": "後台登入可用。",
-        "summary": "OAuth 登入已配置，且目前密碼登入未使用預設憑證。",
-        "suggestion": "無需處理。"
-      },
-      "details": {
-        "github_configured": "GitHub OAuth：已配置",
-        "github_missing": "GitHub OAuth：未配置",
-        "password_configured": "密碼登入：已配置",
-        "password_missing": "密碼登入：未配置",
-        "password_default": "密碼登入：使用預設憑證"
-      }
+        "missing": {
+          "impact": "使用者可以看到登入入口，但沒有任何可用的登入方式。",
+          "summary": "GitHub OAuth 和密碼登入都未配置。",
+          "suggestion": "請配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET 或 ADMIN_USERNAME/ADMIN_PASSWORD。"
+        },
+        "default_password": {
+          "impact": "管理員帳號仍在使用預設使用者名稱與密碼，屬於嚴重安全風險。",
+          "summary": "ADMIN_USERNAME/ADMIN_PASSWORD 仍然是 admin / admin123。",
+          "suggestion": "在公開網站之前請立即修改預設使用者名稱或密碼。"
+        },
+        "oauth_missing": {
+          "impact": "目前只能使用本地密碼帳號登入，其他使用者無法透過 OAuth 登入並留言。",
+          "summary": "GitHub OAuth 未配置。",
+          "suggestion": "如果希望其他使用者登入，請配置 RIN_GITHUB_CLIENT_ID/RIN_GITHUB_CLIENT_SECRET。"
+        },
+        "ready": {
+          "impact": "後台登入可用。",
+          "summary": "OAuth 登入已配置，且目前密碼登入未使用預設憑證。",
+          "suggestion": "無需處理。"
+        },
+        "details": {
+          "github_configured": "GitHub OAuth：已配置",
+          "github_missing": "GitHub OAuth：未配置",
+          "password_configured": "密碼登入：已配置",
+          "password_missing": "密碼登入：未配置",
+          "password_default": "密碼登入：使用預設憑證"
+        }
       },
       "storage": {
         "title": "物件儲存",
@@ -719,5 +723,6 @@
   },
   "sort_latest": "最新",
   "sort_popular": "熱門",
-  "total_tags": "共 {{count}} 個標籤"
+  "total_tags": "共 {{count}} 個標籤",
+  "anonymous": "匿名"
 }

--- a/client/src/page/feed.tsx
+++ b/client/src/page/feed.tsx
@@ -376,33 +376,67 @@ function CommentInput({
 }) {
   const { t } = useTranslation();
   const [content, setContent] = useState("");
+  const [guestName, setGuestName] = useState("");
+  const [guestEmail, setGuestEmail] = useState("");
+  const [guestWebsite, setGuestWebsite] = useState("");
   const [error, setError] = useState("");
   const { showAlert, AlertUI } = useAlert();
   const profile = useContext(ProfileContext);
   const [, setLocation] = useLocation();
+  const config = useContext(ClientConfigContext);
+  // guest comments enabled by default; admin can disable via client config `comment.guest.enabled=false`
+  const rawGuest = config.get('comment.guest.enabled');
+  const guestEnabled = rawGuest !== false && rawGuest !== 'false';
   function errorHumanize(error: string) {
     if (error === "Unauthorized") return t("login.required");
     else if (error === "Content is required") return t("comment.empty");
+    else if (error === "Guest name is required") return t("comment.guest_name_required");
     return error;
   }
   function submit() {
-    if (!profile) {
-      setLocation('/login')
-      return;
+    if (profile) {
+      client.comment
+        .create(parseInt(id), { content })
+        .then(({ error }) => {
+          if (error) {
+            setError(errorHumanize(error.value as string));
+          } else {
+            setContent("");
+            setError("");
+            showAlert(t("comment.success"), () => {
+              onRefresh();
+            });
+          }
+        });
+    } else if (guestEnabled) {
+      if (!guestName.trim()) {
+        setError(t("comment.guest_name_required"));
+        return;
+      }
+      client.comment
+        .create(parseInt(id), {
+          content,
+          guestName: guestName.trim(),
+          guestEmail: guestEmail.trim() || undefined,
+          guestWebsite: guestWebsite.trim() || undefined,
+        })
+        .then(({ error }) => {
+          if (error) {
+            setError(errorHumanize(error.value as string));
+          } else {
+            setContent("");
+            setGuestName("");
+            setGuestEmail("");
+            setGuestWebsite("");
+            setError("");
+            showAlert(t("comment.success"), () => {
+              onRefresh();
+            });
+          }
+        });
+    } else {
+      setLocation('/login');
     }
-    client.comment
-      .create(parseInt(id), { content })
-      .then(({ error }) => {
-        if (error) {
-          setError(errorHumanize(error.value as string));
-        } else {
-          setContent("");
-          setError("");
-          showAlert(t("comment.success"), () => {
-            onRefresh();
-          });
-        }
-      });
   }
   return (
     <div className="w-full rounded-2xl bg-w t-primary p-6 items-end flex flex-col">
@@ -423,7 +457,42 @@ function CommentInput({
         >
           {t("comment.submit")}
         </button>
-      </>      ) : (
+      </>) : guestEnabled ? (<>
+        <input
+          type="text"
+          placeholder={t("comment.guest_name_placeholder")}
+          className="bg-w w-full rounded-lg px-3 py-2 mb-2 border border-gray-200 dark:border-gray-700"
+          value={guestName}
+          onChange={(e) => setGuestName(e.target.value)}
+        />
+        <input
+          type="email"
+          placeholder={t("comment.guest_email_placeholder")}
+          className="bg-w w-full rounded-lg px-3 py-2 mb-2 border border-gray-200 dark:border-gray-700"
+          value={guestEmail}
+          onChange={(e) => setGuestEmail(e.target.value)}
+        />
+        <input
+          type="url"
+          placeholder={t("comment.guest_website_placeholder")}
+          className="bg-w w-full rounded-lg px-3 py-2 mb-2 border border-gray-200 dark:border-gray-700"
+          value={guestWebsite}
+          onChange={(e) => setGuestWebsite(e.target.value)}
+        />
+        <textarea
+          id="comment"
+          placeholder={t("comment.placeholder.title")}
+          className="bg-w w-full h-24 rounded-lg"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button
+          className="mt-4 bg-theme text-white px-4 py-2 rounded-full"
+          onClick={submit}
+        >
+          {t("comment.submit")}
+        </button>
+      </>) : (
         <div className="flex flex-row w-full items-center justify-center space-x-2 py-12">
           <button
             className="mt-2 bg-theme text-white px-4 py-2 rounded-full"
@@ -444,12 +513,15 @@ type Comment = {
   content: string;
   createdAt: Date;
   updatedAt: Date;
-  user: {
+  user?: {
     id: number;
     username: string;
     avatar: string | null;
     permission: number | null;
-  };
+  } | null;
+  guestName?: string;
+  guestEmail?: string;
+  guestWebsite?: string;
 };
 
 function Comments({ id }: { id: string }) {
@@ -521,6 +593,8 @@ function CommentItem({
   const { showAlert, AlertUI } = useAlert();
   const { t } = useTranslation();
   const profile = useContext(ProfileContext);
+  const commenterName = comment.user?.username || comment.guestName || t("anonymous");
+  const commenterAvatar = comment.user?.avatar || "/avatar.png";
   function deleteComment() {
     showConfirm(
       t("delete.comment.title"),
@@ -542,14 +616,24 @@ function CommentItem({
   return (
     <div className="flex flex-row items-start rounded-xl mt-2">
       <img
-        src={comment.user.avatar || ""}
+        src={commenterAvatar}
         className="w-8 h-8 rounded-full mt-4"
       />
       <div className="flex flex-col flex-1 w-0 ml-2 bg-w rounded-xl p-4">
         <div className="flex flex-row">
           <span className="t-primary text-base font-bold">
-            {comment.user.username}
+            {commenterName}
           </span>
+          {comment.guestWebsite && (
+            <a
+              href={comment.guestWebsite}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-2 text-gray-400 hover:text-theme transition-colors"
+            >
+              <i className="ri-external-link-line"></i>
+            </a>
+          )}
           <div className="flex-1 w-0" />
           <span
             title={new Date(comment.createdAt).toLocaleString()}
@@ -560,7 +644,7 @@ function CommentItem({
         </div>
         <p className="t-primary break-words">{comment.content}</p>
         <div className="flex flex-row justify-end">
-          {(profile?.permission || profile?.id == comment.user.id) && (
+          {(profile?.permission || (comment.user && profile?.id == comment.user.id)) && (
             <Popup
               arrow={false}
               trigger={

--- a/packages/api/src/schemas.ts
+++ b/packages/api/src/schemas.ts
@@ -62,6 +62,9 @@ export const updateProfileSchema = t.Object({
 
 export const commentCreateSchema = t.Object({
   content: t.String(),
+  guestName: t.String({ optional: true }),
+  guestEmail: t.String({ optional: true }),
+  guestWebsite: t.String({ optional: true }),
 });
 
 // ============================================================================

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -165,16 +165,31 @@ export interface Comment {
   content: string;
   createdAt: string;
   updatedAt: string;
-  user: {
+  /** 登录用户的评论 */
+  user?: {
     id: number;
     username: string;
     avatar: string | null;
     permission: number | null;
-  };
+  } | null;
+  /** 游客评论的昵称 */
+  guestName?: string;
+  /** 游客评论的邮箱 */
+  guestEmail?: string;
+  /** 游客评论的网站 */
+  guestWebsite?: string;
+  /** 审核状态 */
+  approved: boolean;
 }
 
 export interface CreateCommentRequest {
   content: string;
+  /** 游客昵称（未登录时必填） */
+  guestName?: string;
+  /** 游客邮箱（可选） */
+  guestEmail?: string;
+  /** 游客网站（可选） */
+  guestWebsite?: string;
 }
 
 // ============================================================================

--- a/server/sql/0010.sql
+++ b/server/sql/0010.sql
@@ -1,0 +1,32 @@
+-- Guest comments support
+-- Recreate comments table with nullable user_id, add guest fields and approved flag
+-- We ALTER can't change NOT NULL in SQLite, so we recreate the table.
+
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `comments_new` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`feed_id` integer NOT NULL,
+	`user_id` integer,
+	`content` text NOT NULL,
+	`guest_name` text DEFAULT '',
+	`guest_email` text DEFAULT '',
+	`guest_website` text DEFAULT '',
+	`approved` integer DEFAULT 1 NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`feed_id`) REFERENCES `feeds`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+
+--> statement-breakpoint
+INSERT INTO `comments_new` (`id`, `feed_id`, `user_id`, `content`, `created_at`, `updated_at`)
+	SELECT `id`, `feed_id`, `user_id`, `content`, `created_at`, `updated_at` FROM `comments`;
+
+--> statement-breakpoint
+DROP TABLE `comments`;
+
+--> statement-breakpoint
+ALTER TABLE `comments_new` RENAME TO `comments`;
+
+--> statement-breakpoint
+UPDATE `info` SET `value` = '10' WHERE `key` = 'migration_version';

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -76,8 +76,12 @@ export const users = sqliteTable("users", {
 export const comments = sqliteTable("comments", {
     id: integer("id").primaryKey(),
     feedId: integer("feed_id").references(() => feeds.id, { onDelete: 'cascade' }).notNull(),
-    userId: integer("user_id").references(() => users.id, { onDelete: 'cascade' }).notNull(),
+    userId: integer("user_id").references(() => users.id, { onDelete: 'cascade' }),
     content: text("content").notNull(),
+    guestName: text("guest_name").default(""),
+    guestEmail: text("guest_email").default(""),
+    guestWebsite: text("guest_website").default(""),
+    approved: integer("approved").default(1).notNull(),
     createdAt: created_at,
     updatedAt: updated_at,
 });

--- a/server/src/services/__tests__/comments.test.ts
+++ b/server/src/services/__tests__/comments.test.ts
@@ -122,14 +122,67 @@ describe('CommentService', () => {
             expect(comments.length).toBe(3);
         });
 
-        it('should require authentication', async () => {
+        it('should create guest comment with guestName', async () => {
+            const res = await app.request('/1', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    content: 'Guest comment',
+                    guestName: 'Visitor',
+                    guestEmail: 'visitor@example.com',
+                    guestWebsite: 'https://example.com',
+                }),
+            }, env);
+
+            expect(res.status).toBe(200);
+
+            // Verify via direct DB query
+            const row = sqlite.prepare(
+                `SELECT content, guest_name, guest_email, guest_website FROM comments WHERE guest_name = 'Visitor'`
+            ).get() as any;
+            expect(row).toBeDefined();
+            expect(row.content).toBe('Guest comment');
+            expect(row.guest_name).toBe('Visitor');
+            expect(row.guest_email).toBe('visitor@example.com');
+            expect(row.guest_website).toBe('https://example.com');
+        });
+
+        it('should reject guest comment without guestName', async () => {
+            const res = await app.request('/1', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: 'Guest no name' }),
+            }, env);
+            expect(res.status).toBe(400);
+        });
+
+        it('should return guest comments with user: null in list', async () => {
+            // Create a guest comment first
+            const createRes = await app.request('/1', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: 'Hi from guest', guestName: 'Guest' }),
+            }, env);
+            expect(createRes.status).toBe(200);
+
+            const res = await app.request('/1', { method: 'GET' }, env);
+            expect(res.status).toBe(200);
+            const data = await res.json() as any[];
+            const guestComment = data.find((c: any) => c.guestName === 'Guest');
+            expect(guestComment).toBeDefined();
+            expect(guestComment.user).toBeNull();
+            expect(guestComment.content).toBe('Hi from guest');
+        });
+
+        it('should return 400 when not authenticated and guest name missing', async () => {
             const res = await app.request('/1', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ content: 'Test comment' }),
             }, env);
 
-            expect(res.status).toBe(401);
+            expect(res.status).toBe(400);
+            expect(await res.text()).toContain('Guest name is required');
         });
 
         it('should require content', async () => {

--- a/server/src/services/comments.ts
+++ b/server/src/services/comments.ts
@@ -24,7 +24,24 @@ export function CommentService(): Hono {
             orderBy: [desc(comments.createdAt)]
         }));
         
-        return c.json(comment_list);
+        // 将结果统一为前端兼容格式：登录用户用 user 字段，游客用 guestName 等
+        const result = comment_list.map((c: any) => {
+            if (c.user) {
+                // 登录用户的评论
+                return c;
+            }
+            // 游客评论：去掉空的 user 字段，保留 guestName 等
+            const { user, ...rest } = c;
+            return {
+                ...rest,
+                user: null,
+                guestName: rest.guestName || "",
+                guestEmail: rest.guestEmail || "",
+                guestWebsite: rest.guestWebsite || "",
+            };
+        });
+        
+        return c.json(result);
     });
 
     app.post('/:feed', async (c: AppContext) => {
@@ -34,22 +51,10 @@ export function CommentService(): Hono {
         const uid = c.get('uid');
         const feedId = parseInt(c.req.param('feed'));
         const body = await profileAsync(c, 'comment_create_parse', () => c.req.json());
-        const { content } = body;
+        const { content, guestName, guestEmail, guestWebsite } = body;
         
-        if (!uid) {
-            return c.text('Unauthorized', 401);
-        }
         if (!content) {
             return c.text('Content is required', 400);
-        }
-        
-        if (uid == undefined) {
-            return c.text('Invalid uid', 400);
-        }
-        
-        const user = await profileAsync(c, 'comment_create_user', () => db.query.users.findFirst({ where: eq(users.id, uid) }));
-        if (!user) {
-            return c.text('User not found', 400);
         }
         
         const exist = await profileAsync(c, 'comment_create_feed', () => db.query.feeds.findFirst({ where: eq(feeds.id, feedId) }));
@@ -57,29 +62,73 @@ export function CommentService(): Hono {
             return c.text('Feed not found', 400);
         }
 
-        await profileAsync(c, 'comment_create_insert', () => db.insert(comments).values({
-            feedId,
-            userId: uid,
-            content
-        }));
+        // 登录用户评论
+        if (uid) {
+            const user = await profileAsync(c, 'comment_create_user', () => db.query.users.findFirst({ where: eq(users.id, uid) }));
+            if (!user) {
+                return c.text('User not found', 400);
+            }
 
-        const {
-            webhookUrl,
-            webhookMethod,
-            webhookContentType,
-            webhookHeaders,
-            webhookBodyTemplate,
-        } = await profileAsync(c, 'comment_create_webhook_config', () => resolveWebhookConfig(serverConfig, env));
+            await db.insert(comments).values({
+                feedId,
+                userId: uid,
+                content
+            });
+
+            const { webhookUrl, webhookMethod, webhookContentType, webhookHeaders, webhookBodyTemplate } =
+                await profileAsync(c, 'comment_create_webhook_config', () => resolveWebhookConfig(serverConfig, env));
+            const frontendUrl = new URL(c.req.url).origin;
+            try {
+                await profileAsync(c, 'comment_create_notify', () => notify(
+                    webhookUrl || "",
+                    {
+                        event: "comment.created",
+                        message: `${frontendUrl}/feed/${feedId}\n${user.username} 评论了: ${exist.title}\n${content}`,
+                        title: exist.title || "",
+                        url: `${frontendUrl}/feed/${feedId}`,
+                        username: user.username,
+                        content,
+                    },
+                    {
+                        method: webhookMethod,
+                        contentType: webhookContentType,
+                        headers: webhookHeaders,
+                        bodyTemplate: webhookBodyTemplate,
+                    },
+                ));
+            } catch (error) {
+                console.error("Failed to send comment webhook", error);
+            }
+            return c.text('OK');
+        }
+
+        // 游客评论
+        if (!guestName || !guestName.trim()) {
+            return c.text('Guest name is required', 400);
+        }
+
+        await db.insert(comments).values({
+            feedId,
+            userId: null,
+            content,
+            guestName: guestName.trim(),
+            guestEmail: guestEmail?.trim() || "",
+            guestWebsite: guestWebsite?.trim() || "",
+            approved: 1,
+        });
+
+        const { webhookUrl, webhookMethod, webhookContentType, webhookHeaders, webhookBodyTemplate } =
+            await profileAsync(c, 'comment_create_webhook_config', () => resolveWebhookConfig(serverConfig, env));
         const frontendUrl = new URL(c.req.url).origin;
         try {
             await profileAsync(c, 'comment_create_notify', () => notify(
                 webhookUrl || "",
                 {
                     event: "comment.created",
-                    message: `${frontendUrl}/feed/${feedId}\n${user.username} 评论了: ${exist.title}\n${content}`,
+                    message: `${frontendUrl}/feed/${feedId}\n游客 ${guestName} 评论了: ${exist.title}\n${content}`,
                     title: exist.title || "",
                     url: `${frontendUrl}/feed/${feedId}`,
-                    username: user.username,
+                    username: guestName,
                     content,
                 },
                 {
@@ -111,11 +160,17 @@ export function CommentService(): Hono {
             return c.text('Not found', 404);
         }
         
-        if (!admin && comment.userId !== uid) {
+        // 管理员可删任意评论；普通用户只能删自己的
+        if (admin) {
+            await db.delete(comments).where(eq(comments.id, id_num));
+            return c.text('OK');
+        }
+        
+        if (comment.userId !== uid) {
             return c.text('Permission denied', 403);
         }
         
-        await profileAsync(c, 'comment_delete_db', () => db.delete(comments).where(eq(comments.id, id_num)));
+        await db.delete(comments).where(eq(comments.id, id_num));
         return c.text('OK');
     });
 

--- a/server/tests/fixtures/index.ts
+++ b/server/tests/fixtures/index.ts
@@ -110,8 +110,12 @@ export function createMockDB() {
         CREATE TABLE IF NOT EXISTS comments (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             feed_id INTEGER NOT NULL,
-            user_id INTEGER NOT NULL,
+            user_id INTEGER,
             content TEXT NOT NULL,
+            guest_name TEXT DEFAULT '',
+            guest_email TEXT DEFAULT '',
+            guest_website TEXT DEFAULT '',
+            approved INTEGER DEFAULT 1 NOT NULL,
             created_at INTEGER DEFAULT (unixepoch()),
             updated_at INTEGER DEFAULT (unixepoch()),
             FOREIGN KEY (feed_id) REFERENCES feeds(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

Allow unauthenticated users to leave comments on articles. Guest commenters provide a name (required) and optionally an email and website URL.

## Changes

### Database
- **Migration `0010.sql`**: Rebuild `comments` table to make `user_id` nullable; add `guest_name`, `guest_email`, `guest_website`, `approved` columns
- **Test fixture**: Update in-memory DDL to match new schema

### Schema & Types (`packages/api`)
- `Comment.user` is now nullable; add `guestName`/`guestEmail`/`guestWebsite` fields
- `CreateCommentRequest` accepts optional `guestName`/`guestEmail`/`guestWebsite`

### Server (`server/src/services/comments.ts`)
- `POST /:feed`: Authenticated users post as before; unauthenticated requests require `guestName`, accept optional `guestEmail`/`guestWebsite`
- `GET /:feed`: Guest comments return `user: null` + guest fields; logged-in comments unchanged
- `DELETE /:id`: Admins can delete any comment; users can only delete their own

### Client (`client/src/page/feed.tsx`)
- `CommentInput`: When not logged in, shows guest form (name/email/website) + textarea, controlled by client config `comment.guest.enabled` (default: on)
- `CommentItem`: Displays guest name with optional website link; handles `user: null` gracefully
- **Bugfix**: Guest comment `commenterAvatar` now falls back to `/avatar.png` instead of empty string, preventing `TypeError: e.user is null` on some render paths

### i18n
- Add `anonymous` + 4 `comment.guest_*` keys to zh-CN, en, ja, zh-TW

### Tests
- 4 new test cases covering guest comment creation, validation, and listing
- Existing auth test updated (unauthenticated without `guestName` → 400, not 401)