### PR TITLE
fix: 增强内容渲染和 AI 摘要的稳定性

### DIFF
--- a/client/src/components/feed_card.tsx
+++ b/client/src/components/feed_card.tsx
@@ -13,7 +13,7 @@ function FeedCardImage({ src, variant }: { src: string; variant: FeedCardVariant
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const { src: cleanSrc, blurhash, width, height } = parseImageUrlMetadata(src);
     const { failed, imageRef, loaded, onError, onLoad } = useImageLoadState(cleanSrc);
-    const aspectRatio = width && height ? `${width} / ${height}` : undefined;
+    const aspectRatio = width && height ? `${width} / ${height}` : "16 / 9";
     const imageFrameClass =
         variant === "editorial"
             ? "relative flex max-h-80 w-full flex-row items-center overflow-hidden rounded-[20px]"
@@ -91,7 +91,7 @@ export type FeedCardProps = {
     top?: number;
     title: string;
     summary: string;
-    hashtags: { id: number, name: string }[];
+    hashtags?: { id: number, name: string }[];
     createdAt: Date;
     updatedAt: Date;
     preview?: boolean;
@@ -101,6 +101,7 @@ export type FeedCardProps = {
 export function FeedCard({ id, title, avatar, draft, listed, top, summary, hashtags, createdAt, updatedAt, preview = false, variant }: FeedCardProps) {
     const { t } = useTranslation();
     const siteConfig = useSiteConfig();
+    const safeHashtags = Array.isArray(hashtags) ? hashtags : [];
     const activeVariant = normalizeFeedCardVariant(variant ?? siteConfig.feedCardVariant);
     const styles = FEED_CARD_STYLES[activeVariant];
     const body = (
@@ -128,9 +129,9 @@ export function FeedCard({ id, title, avatar, draft, listed, top, summary, hasht
                     {top === 1 && <span className="text-theme">{t('article.top.title')}</span>}
                 </p>
                 <p className={`${styles.summary} ${activeVariant === "editorial" ? "mt-4 max-w-3xl" : ""}`}>{summary}</p>
-                {hashtags.length > 0 &&
+                {safeHashtags.length > 0 &&
                     <div className={`flex flex-row flex-wrap justify-start gap-2 ${activeVariant === "editorial" ? "mt-4" : "mt-2 gap-x-2"}`}>
-                        {hashtags.map(({ name }, index) => (
+                        {safeHashtags.map(({ name }, index) => (
                             <HashTag key={index} name={name} />
                         ))}
                     </div>

--- a/client/src/page/compat-tasks.tsx
+++ b/client/src/page/compat-tasks.tsx
@@ -74,7 +74,7 @@ export function CompatTasksPage() {
         return;
       }
 
-      const items = data?.items || [];
+      const items = Array.isArray(data?.items) ? data.items : [];
       setBlurhashProgress({ total: items.length, processed: 0, updated: 0, failed: 0 });
 
       let processed = 0;

--- a/client/src/page/feed.tsx
+++ b/client/src/page/feed.tsx
@@ -46,6 +46,7 @@ export function FeedPage({ id, TOC, clean }: { id: string, TOC: () => JSX.Elemen
   const counterEnabled = config.getBoolean('counter.enabled');
   const hasAISummary = Boolean(feed?.ai_summary?.trim());
   const showAISummaryState = feed?.ai_summary_status === "pending" || feed?.ai_summary_status === "processing" || feed?.ai_summary_status === "failed";
+  const hashtags = Array.isArray(feed?.hashtags) ? feed.hashtags : [];
   function deleteFeed() {
     // Confirm
     showConfirm(
@@ -151,7 +152,7 @@ export function FeedPage({ id, TOC, clean }: { id: string, TOC: () => JSX.Elemen
           <meta name="author" content={feed.user.username} />
           <meta
             name="keywords"
-            content={feed.hashtags.map(({ name }) => name).join(", ")}
+            content={hashtags.map(({ name }) => name).join(", ")}
           />
           <meta
             name="description"
@@ -282,9 +283,9 @@ export function FeedPage({ id, TOC, clean }: { id: string, TOC: () => JSX.Elemen
                 )}
                 <Markdown content={feed.content} />
                 <div className="mt-6 flex flex-col gap-2">
-                  {feed.hashtags.length > 0 && (
+                  {hashtags.length > 0 && (
                     <div className="flex flex-row flex-wrap gap-x-2">
-                      {feed.hashtags.map(({ name }, index) => (
+                      {hashtags.map(({ name }, index) => (
                         <HashTag key={index} name={name} />
                       ))}
                     </div>

--- a/client/src/page/feeds.tsx
+++ b/client/src/page/feeds.tsx
@@ -38,6 +38,8 @@ export function FeedsPage() {
     const page = tryInt(1, query.get("page"))
     const limit = tryInt(siteConfig.pageSize, query.get("limit"))
     const feedListClass = siteConfig.feedLayout === "masonry" ? "wauto columns-1 gap-5 ani-show md:columns-2" : "wauto flex flex-col ani-show";
+    const currentFeeds = feeds[listState] ?? { size: 0, data: [], hasNext: false };
+    const currentFeedData = Array.isArray(currentFeeds.data) ? currentFeeds.data : [];
     const ref = useRef("")
     function fetchFeeds(type: FeedType) {
         client.feed.list({
@@ -83,7 +85,7 @@ export function FeedsPage() {
                         </p>
                         <div className="flex flex-row justify-between">
                             <p className="text-sm mt-4 text-neutral-500 font-normal">
-                                {t('article.total$count', { count: feeds[listState]?.size })}
+                                {t('article.total$count', { count: currentFeeds.size })}
                             </p>
                             {profile?.permission &&
                                 <div className="flex flex-row space-x-4">
@@ -99,7 +101,7 @@ export function FeedsPage() {
                     </div>
                     <Waiting for={status === 'idle'}>
                         <div className={feedListClass}>
-                            {feeds[listState].data.map(({ id, ...feed }: any) => (
+                            {currentFeedData.map(({ id, ...feed }: any) => (
                                 <FeedCard key={id} id={id} {...feed} />
                             ))}
                         </div>
@@ -111,7 +113,7 @@ export function FeedsPage() {
                                 </Link>
                             }
                             <div className="flex-1" />
-                            {feeds[listState]?.hasNext &&
+                            {currentFeeds.hasNext &&
                                 <Link href={`/?type=${listState}&page=${(page + 1)}`}
                                     className={`text-sm font-normal rounded-full px-4 py-2 text-white bg-theme`}>
                                     {t('next')}

--- a/client/src/page/hashtag.tsx
+++ b/client/src/page/hashtag.tsx
@@ -39,6 +39,7 @@ export function HashtagPage({ name }: { name: string }) {
     const [status, setStatus] = useState<'loading' | 'idle'>('idle')
     const [hashtag, setHashtag] = useState<FeedsData>()
     const feedListClass = siteConfig.feedLayout === "masonry" ? "wauto columns-1 gap-5 md:columns-2" : "wauto flex flex-col";
+    const hashtagFeeds = Array.isArray(hashtag?.feeds) ? hashtag.feeds : [];
     const ref = useRef("")
     function fetchFeeds() {
         const nameDecoded = decodeURI(name)
@@ -73,13 +74,13 @@ export function HashtagPage({ name }: { name: string }) {
                         </p>
                         <div className="flex flex-row justify-between">
                             <p className="text-sm mt-4 text-neutral-500 font-normal">
-                                {t('article.total$count', { count: hashtag?.feeds?.length })}
+                                {t('article.total$count', { count: hashtagFeeds.length })}
                             </p>
                         </div>
                     </div>
                     <Waiting for={status === 'idle'}>
                         <div className={feedListClass}>
-                            {hashtag?.feeds?.map(({ id, ...feed }: any) => (
+                            {hashtagFeeds.map(({ id, ...feed }: any) => (
                                 <FeedCard key={id} id={id} {...feed} />
                             ))}
                         </div>

--- a/client/src/page/health.tsx
+++ b/client/src/page/health.tsx
@@ -67,7 +67,7 @@ export function HealthPage() {
           return;
         }
         if (data) {
-          setItems(data.items);
+          setItems(Array.isArray(data.items) ? data.items : []);
           setSummary(data.summary);
           setGeneratedAt(data.generatedAt);
         }

--- a/client/src/page/moments.tsx
+++ b/client/src/page/moments.tsx
@@ -62,13 +62,14 @@ export function MomentsPage() {
             limit: limit
         }).then(({ data }) => {
             if (data) {
-                setLength(data.data.length)
+                const momentData = Array.isArray(data.data) ? data.data : [];
+                setLength(momentData.length)
                 setHasNextPage(data.hasNext)
                 
                 if (append) {
-                    setMoments(prev => [...prev, ...data.data] as any)
+                    setMoments(prev => [...prev, ...momentData] as any)
                 } else {
-                    setMoments(data.data as any)
+                    setMoments(momentData as any)
                 }
                 
                 setCurrentPage(page)

--- a/client/src/page/queue-status.tsx
+++ b/client/src/page/queue-status.tsx
@@ -105,7 +105,7 @@ export function QueueStatusPage() {
           setQueueConfigured(data.queueConfigured);
           setGeneratedAt(data.generatedAt);
           setSummary(data.summary);
-          setItems(data.items);
+          setItems(Array.isArray(data.items) ? data.items : []);
         }
       })
       .finally(() => setLoading(false));

--- a/client/src/page/search.tsx
+++ b/client/src/page/search.tsx
@@ -25,6 +25,7 @@ export function SearchPage({ keyword }: { keyword: string }) {
     const page = tryInt(1, query.get("page"))
     const limit = tryInt(siteConfig.pageSize, query.get("limit"))
     const feedListClass = siteConfig.feedLayout === "masonry" ? "wauto columns-1 gap-5 md:columns-2" : "wauto flex flex-col";
+    const feedData = Array.isArray(feeds?.data) ? feeds.data : [];
     const ref = useRef("")
     function fetchFeeds() {
         if (!keyword) return
@@ -70,7 +71,7 @@ export function SearchPage({ keyword }: { keyword: string }) {
                     </div>
                     <Waiting for={status === 'idle'}>
                         <div className={feedListClass}>
-                            {feeds?.data.map(({ id, ...feed }: any) => (
+                            {feedData.map(({ id, ...feed }: any) => (
                                 <FeedCard key={id} id={id} {...feed} />
                             ))}
                         </div>

--- a/client/src/page/writing.tsx
+++ b/client/src/page/writing.tsx
@@ -189,7 +189,7 @@ export function WritingPage({ id }: { id?: number }) {
         .then(({ data }) => {
           if (data) {
             if (title == "" && data.title) setTitle(data.title);
-            if (tags == "" && data.hashtags)
+            if (tags == "" && Array.isArray(data.hashtags))
               setTags(data.hashtags.map(({ name }: {name: string}) => `#${name}`).join(" "));
             if (alias == "" && (data as any).alias) setAlias((data as any).alias);
             if (content == "") setContent(data.content);

--- a/client/src/remark/remarkMermaid.ts
+++ b/client/src/remark/remarkMermaid.ts
@@ -3,8 +3,8 @@ import type { Content, Root } from 'mdast';
 
 function processNode(child: Content, index: number, siblings: Content[]) {
   if (child.type !== 'code') {
-    if ('children' in child) {
-      child.children.map(processNode);
+    if ('children' in child && Array.isArray(child.children)) {
+      child.children.forEach(processNode);
     }
     return;
   }
@@ -20,7 +20,9 @@ function processNode(child: Content, index: number, siblings: Content[]) {
 }
 
 const remarkMermaid: Plugin<[], Root> = () => (root: Root) => {
-  root.children.map(processNode)
+  if (Array.isArray(root.children)) {
+    root.children.forEach(processNode)
+  }
 };
 
 export default remarkMermaid;

--- a/server/src/utils/ai.ts
+++ b/server/src/utils/ai.ts
@@ -234,8 +234,8 @@ export async function generateAISummaryResult(
         if (provider === 'worker-ai') {
             const fullModelName = getWorkerAIModelId(model);
             result = await executeWorkerAI(
-                env, 
-                fullModelName, 
+                env,
+                fullModelName,
                 summaryMessages,
             );
         } else {
@@ -250,7 +250,16 @@ export async function generateAISummaryResult(
             };
         }
 
-        return { summary: result, skipped: false };
+        const cleaned = stripReasoningTags(result);
+        if (!cleaned.trim()) {
+            return {
+                summary: null,
+                skipped: false,
+                error: `AI response contained only reasoning tags with no final answer (provider "${provider}", model "${model}")`,
+            };
+        }
+
+        return { summary: cleaned, skipped: false };
     } catch (error) {
         console.error("[AI Summary] Failed to generate summary:", error);
         return {
@@ -259,6 +268,20 @@ export async function generateAISummaryResult(
             error: error instanceof Error ? error.message : String(error),
         };
     }
+}
+
+export function stripReasoningTags(text: string): string {
+    if (!text) return "";
+
+    let out = text;
+    out = out.replace(/<think(?:\s[^>]*)?>[\s\S]*?<\/think\s*>/gi, "");
+    out = out.replace(/<think(?:\s[^>]*)?>[\s\S]*$/gi, "");
+    out = out.replace(/<thinking(?:\s[^>]*)?>[\s\S]*?<\/thinking\s*>/gi, "");
+    out = out.replace(/<thinking(?:\s[^>]*)?>[\s\S]*$/gi, "");
+    out = out.replace(/<reasoning(?:\s[^>]*)?>[\s\S]*?<\/reasoning\s*>/gi, "");
+    out = out.replace(/<reasoning(?:\s[^>]*)?>[\s\S]*$/gi, "");
+
+    return out.trim();
 }
 
 /**

--- a/server/src/utils/image.ts
+++ b/server/src/utils/image.ts
@@ -67,17 +67,19 @@ export function contentHasImagesMissingMetadata(content: string) {
 }
 
 export function extractImage(content: string) {
-    const img_reg = /!\[.*?\]\((\S+?)(?:\s+"[^"]*")?\)/;
-    const img_match = img_reg.exec(content);
-    let avatar: string | undefined = undefined;
-    if (img_match) {
-        avatar = stripImageMetadataFromUrl(img_match[1]);
+    const urls = listContentImageUrls(content);
+    for (const url of urls) {
+        if (url.startsWith('data:')) continue;
+        return stripImageMetadataFromUrl(url);
     }
-    return avatar;
+    return undefined;
 }
 
 export function extractImageWithMetadata(content: string) {
-    const img_reg = /!\[.*?\]\((\S+?)(?:\s+"[^"]*")?\)/;
-    const img_match = img_reg.exec(content);
-    return img_match?.[1];
+    const urls = listContentImageUrls(content);
+    for (const url of urls) {
+        if (url.startsWith('data:')) continue;
+        return url;
+    }
+    return undefined;
 }


### PR DESCRIPTION
## 概述

这个 PR 合并了一组通用的稳定性修复：

- 对文章页、列表页、搜索页、标签页等位置的接口数组字段增加兜底，避免后端返回缺失字段时触发运行时 `.map` 崩溃。
- 当 feed card 封面图缺少宽高元数据时，提供默认比例，避免图片布局异常。
- 封面图提取同时支持 Markdown 图片和 HTML `<img>` 标签，并跳过内嵌的 `data:` URI。
- Mermaid remark 插件在遍历 AST 子节点时增加防御式判断。
- 在保存 AI 摘要前过滤常见 reasoning 标签（`<think>`、`<thinking>`、`<reasoning>`），避免模型推理内容泄漏到摘要中。

## 范围说明

这个 PR 有意排除了所有个人站点相关改动，包括：部署配置、音乐集成、存储后端、域名、凭据、实例定制逻辑等。这里只保留适合上游合并的通用修复。

## 测试

- `bun run check`

说明：本地 Turbo 会输出一个既有的 workspace 解析警告，但 TypeScript 检查任务已完成。