### PR TITLE
FRO-3: fix feed edit lookup by numeric id

### DIFF
--- a/server/src/services/__tests__/clear-feed-cache.test.ts
+++ b/server/src/services/__tests__/clear-feed-cache.test.ts
@@ -25,7 +25,9 @@ describe('clearFeedCache', () => {
         ]);
         expect(deletedKeys).toEqual([
             { key: 'feed_42', save: false },
-            { key: 'feed_about', save: false }
+            { key: 'feed_id_42', save: false },
+            { key: 'feed_about', save: false },
+            { key: 'feed_alias_about', save: false }
         ]);
     });
 
@@ -42,8 +44,11 @@ describe('clearFeedCache', () => {
 
         expect(deletedKeys).toEqual([
             { key: 'feed_42', save: false },
+            { key: 'feed_id_42', save: false },
             { key: 'feed_about', save: false },
-            { key: 'feed_about-us', save: false }
+            { key: 'feed_alias_about', save: false },
+            { key: 'feed_about-us', save: false },
+            { key: 'feed_alias_about-us', save: false }
         ]);
     });
 });

--- a/server/src/services/__tests__/feed.test.ts
+++ b/server/src/services/__tests__/feed.test.ts
@@ -166,6 +166,76 @@ describe('FeedService', () => {
             expect(data.title).toBe('Test Feed');
         });
 
+        it('should prefer a numeric feed id over another feed numeric alias', async () => {
+            const firstRes = await app.request('/', {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer mock_token_1',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    title: 'Previous Feed',
+                    alias: '2',
+                    content: 'Previous Content',
+                    listed: true,
+                    draft: false,
+                    tags: [],
+                }),
+            }, env);
+            expect(firstRes.status).toBe(200);
+
+            const secondRes = await app.request('/', {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer mock_token_1',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    title: 'Target Feed',
+                    content: 'Target Content',
+                    listed: true,
+                    draft: false,
+                    tags: [],
+                }),
+            }, env);
+            expect(secondRes.status).toBe(200);
+            const secondData = await secondRes.json() as any;
+
+            const getRes = await app.request(`/${secondData.insertedId}`, { method: 'GET' }, env);
+
+            expect(getRes.status).toBe(200);
+            const data = await getRes.json() as any;
+            expect(data.id).toBe(secondData.insertedId);
+            expect(data.title).toBe('Target Feed');
+            expect(data.content).toBe('Target Content');
+        });
+
+        it('should return feed by non-numeric alias', async () => {
+            const createRes = await app.request('/', {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer mock_token_1',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    title: 'Alias Feed',
+                    alias: 'custom-slug',
+                    content: 'Alias Content',
+                    listed: true,
+                    draft: false,
+                    tags: [],
+                }),
+            }, env);
+
+            expect(createRes.status).toBe(200);
+
+            const getRes = await app.request('/custom-slug', { method: 'GET' }, env);
+
+            expect(getRes.status).toBe(200);
+            const data = await getRes.json() as any;
+            expect(data.title).toBe('Alias Feed');
+        });
+
         it('should return AI summary generation status for a queued feed', async () => {
             await serverConfig.set('ai_summary.enabled', 'true', false);
             await serverConfig.set('ai_summary.provider', 'worker-ai', false);

--- a/server/src/services/clear-feed-cache.ts
+++ b/server/src/services/clear-feed-cache.ts
@@ -4,8 +4,13 @@ export async function clearFeedCache(cache: CacheImpl, id: number, alias: string
     await cache.deletePrefix('feeds_');
     await cache.deletePrefix('search_');
     await cache.delete(`feed_${id}`, false);
+    await cache.delete(`feed_id_${id}`, false);
     await cache.deletePrefix(`${id}_previous_feed`);
     await cache.deletePrefix(`${id}_next_feed`);
-    if (alias) await cache.delete(`feed_${alias}`, false);
+    if (alias) {
+        await cache.delete(`feed_${alias}`, false);
+        await cache.delete(`feed_alias_${alias}`, false);
+    }
     if (newAlias && newAlias !== alias) await cache.delete(`feed_${newAlias}`, false);
+    if (newAlias && newAlias !== alias) await cache.delete(`feed_alias_${newAlias}`, false);
 }

--- a/server/src/services/feed.ts
+++ b/server/src/services/feed.ts
@@ -14,6 +14,15 @@ export { clearFeedCache } from "./clear-feed-cache";
 let XMLParser: any;
 let html2md: any;
 
+function parseFeedId(value: string): number | null {
+    if (!/^[1-9]\d*$/.test(value)) {
+        return null;
+    }
+
+    const id = Number(value);
+    return Number.isSafeInteger(id) ? id : null;
+}
+
 async function initWPModules() {
     if (!XMLParser) {
         const fxp = await import("fast-xml-parser");
@@ -194,11 +203,12 @@ export function FeedService(): Hono<{
         const admin = c.get('admin');
         const uid = c.get('uid');
         const id = c.req.param('id');
-        const id_num = parseInt(id);
-        const cacheKey = `feed_${id}`;
+        const id_num = parseFeedId(id);
+        const cacheKey = id_num === null ? `feed_alias_${id}` : `feed_id_${id_num}`;
+        const where = id_num === null ? eq(feeds.alias, id) : eq(feeds.id, id_num);
 
         const feed = await profileAsync(c, 'feed_detail_cache_db', () => cache.getOrSet(cacheKey, () => db.query.feeds.findFirst({
-            where: or(eq(feeds.id, id_num), eq(feeds.alias, id)),
+            where,
             with: {
                 hashtags: {
                     columns: {},
@@ -275,16 +285,14 @@ export function FeedService(): Hono<{
         const db = c.get('db');
         const cache = c.get('cache');
         const id = c.req.param('id');
-        let id_num: number;
+        let id_num = parseFeedId(id);
 
-        if (isNaN(parseInt(id))) {
+        if (id_num === null) {
             const aliasRecord = await profileAsync(c, 'feed_adjacent_alias_lookup', () => db.select({ id: feeds.id }).from(feeds).where(eq(feeds.alias, id)));
             if (aliasRecord.length === 0) {
                 return c.text("Not found", 404);
             }
             id_num = aliasRecord[0].id;
-        } else {
-            id_num = parseInt(id);
         }
 
         const feed = await profileAsync(c, 'feed_adjacent_current', () => db.query.feeds.findFirst({
@@ -660,4 +668,3 @@ type FeedItem = {
     updatedAt: Date;
     tags?: string[];
 }
-


### PR DESCRIPTION
Closes FRO-3
Fixes #518

Summary:
- Resolve numeric feed detail routes by id only, avoiding collisions with another feed's numeric alias.
- Keep non-numeric alias lookup working.
- Split feed detail cache keys by id vs alias and clear both new and legacy keys on updates.

Verification:
- bun test src/services/__tests__/feed.test.ts src/services/__tests__/clear-feed-cache.test.ts
- cd server && bun run test
- cd server && bun run check
- cd client && bun run test
- cd client && bun run check
- cd client && bun run build
- bun run check
- bun run format:check
