### PR TITLE
FRO-4: persist feed alias cache invalidation

### DIFF
--- a/server/src/services/__tests__/clear-feed-cache.test.ts
+++ b/server/src/services/__tests__/clear-feed-cache.test.ts
@@ -12,7 +12,8 @@ describe('clearFeedCache', () => {
             },
             async delete(key: string, save?: boolean) {
                 deletedKeys.push({ key, save });
-            }
+            },
+            async save() {}
         } as any;
 
         await clearFeedCache(cache, 42, 'about', 'about');
@@ -35,7 +36,8 @@ describe('clearFeedCache', () => {
             async deletePrefix() {},
             async delete(key: string, save?: boolean) {
                 deletedKeys.push({ key, save });
-            }
+            },
+            async save() {}
         } as any;
 
         await clearFeedCache(cache, 42, 'about', 'about-us');
@@ -44,6 +46,33 @@ describe('clearFeedCache', () => {
             { key: 'feed_42', save: false },
             { key: 'feed_about', save: false },
             { key: 'feed_about-us', save: false }
+        ]);
+    });
+
+    it('saves after deleting exact detail cache keys', async () => {
+        const operations: string[] = [];
+        const cache = {
+            async deletePrefix(prefix: string) {
+                operations.push(`prefix:${prefix}`);
+            },
+            async delete(key: string, save?: boolean) {
+                operations.push(`delete:${key}:${save}`);
+            },
+            async save() {
+                operations.push('save');
+            }
+        } as any;
+
+        await clearFeedCache(cache, 42, 'about', 'about');
+
+        expect(operations).toEqual([
+            'prefix:feeds_',
+            'prefix:search_',
+            'delete:feed_42:false',
+            'delete:feed_about:false',
+            'prefix:42_previous_feed',
+            'prefix:42_next_feed',
+            'save'
         ]);
     });
 });

--- a/server/src/services/__tests__/feed.test.ts
+++ b/server/src/services/__tests__/feed.test.ts
@@ -362,6 +362,60 @@ describe('FeedService', () => {
             expect(data.title).toBe('Updated Title');
         });
 
+        it('should return updated content through unchanged alias after edit', async () => {
+            await clientConfig.set('counter.enabled', false);
+
+            const createRes = await app.request('/', {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer mock_token_1',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    title: 'Alias Title',
+                    alias: 'alias-post',
+                    content: 'Original alias content',
+                    listed: true,
+                    draft: false,
+                    tags: [],
+                }),
+            }, env);
+
+            expect(createRes.status).toBe(200);
+            const createData = await createRes.json() as any;
+            const feedId = createData.insertedId;
+
+            const cachedAliasRes = await app.request('/alias-post', { method: 'GET' }, env);
+            expect(cachedAliasRes.status).toBe(200);
+            expect(((await cachedAliasRes.json()) as any).content).toBe('Original alias content');
+
+            const updateRes = await app.request(`/${feedId}`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Bearer mock_token_1',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    title: 'Alias Title Updated',
+                    alias: 'alias-post',
+                    content: 'Updated alias content',
+                    listed: true,
+                }),
+            }, env);
+
+            expect(updateRes.status).toBe(200);
+
+            const aliasRes = await app.request('/alias-post', { method: 'GET' }, env);
+            expect(aliasRes.status).toBe(200);
+            const aliasData = await aliasRes.json() as any;
+            expect(aliasData.title).toBe('Alias Title Updated');
+            expect(aliasData.content).toBe('Updated alias content');
+
+            const idRes = await app.request(`/${feedId}`, { method: 'GET' }, env);
+            expect(idRes.status).toBe(200);
+            expect(((await idRes.json()) as any).content).toBe('Updated alias content');
+        });
+
         it('should require admin permission to update', async () => {
             // Create feed first
             const createRes = await app.request('/', {

--- a/server/src/services/clear-feed-cache.ts
+++ b/server/src/services/clear-feed-cache.ts
@@ -3,9 +3,16 @@ import type { CacheImpl } from "../core/hono-types";
 export async function clearFeedCache(cache: CacheImpl, id: number, alias: string | null, newAlias: string | null) {
     await cache.deletePrefix('feeds_');
     await cache.deletePrefix('search_');
-    await cache.delete(`feed_${id}`, false);
+
+    const detailKeys = new Set([`feed_${id}`]);
+    if (alias) detailKeys.add(`feed_${alias}`);
+    if (newAlias && newAlias !== alias) detailKeys.add(`feed_${newAlias}`);
+
+    for (const key of detailKeys) {
+        await cache.delete(key, false);
+    }
+
     await cache.deletePrefix(`${id}_previous_feed`);
     await cache.deletePrefix(`${id}_next_feed`);
-    if (alias) await cache.delete(`feed_${alias}`, false);
-    if (newAlias && newAlias !== alias) await cache.delete(`feed_${newAlias}`, false);
+    await cache.save();
 }

--- a/server/src/services/feed.ts
+++ b/server/src/services/feed.ts
@@ -446,7 +446,7 @@ export function FeedService(): Hono<{
         }
 
         await profileAsync(c, 'feed_top_db', () => db.update(feeds).set({ top }).where(eq(feeds.id, feed.id)));
-        await profileAsync(c, 'feed_top_cache_invalidate', () => clearFeedCache(cache, feed.id, null, null));
+        await profileAsync(c, 'feed_top_cache_invalidate', () => clearFeedCache(cache, feed.id, feed.alias, feed.alias));
         return c.text('Updated');
     });
 
@@ -660,4 +660,3 @@ type FeedItem = {
     updatedAt: Date;
     tags?: string[];
 }
-


### PR DESCRIPTION
Closes FRO-4
Fixes #253

## Summary
- persist feed detail cache deletions for id and alias keys after prefix invalidation
- clear alias detail cache when toggling a feed's top state
- add regression coverage for unchanged-alias edits and cache-helper save ordering

## Verification
- `BUN_INSTALL=/tmp/bun-install BUN_TMPDIR=/tmp/bun-tmp bun test server/src/services/__tests__/clear-feed-cache.test.ts server/src/services/__tests__/feed.test.ts`
- `BUN_INSTALL=/tmp/bun-install BUN_TMPDIR=/tmp/bun-tmp bun --filter './server' test`
- `BUN_INSTALL=/tmp/bun-install BUN_TMPDIR=/tmp/bun-tmp bun --filter './server' check`
- `BUN_INSTALL=/tmp/bun-install BUN_TMPDIR=/tmp/bun-tmp bun --filter './client' test`
- `BUN_INSTALL=/tmp/bun-install BUN_TMPDIR=/tmp/bun-tmp bun --filter './client' check`
- `BUN_INSTALL=/tmp/bun-install BUN_TMPDIR=/tmp/bun-tmp bun --filter './client' build`
- `BUN_INSTALL=/tmp/bun-install BUN_TMPDIR=/tmp/bun-tmp bun run check`
- `BUN_INSTALL=/tmp/bun-install BUN_TMPDIR=/tmp/bun-tmp bun run format:check`
