### PR TITLE
FRO-7: add Markdown editor toolbar

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -133,6 +133,36 @@
   "draft": "Draft",
   "draft_bin": "Draft Bin",
   "edit": "Edit",
+  "markdown_editor": {
+    "placeholder": {
+      "bold": "bold text",
+      "code": "code",
+      "code_block": "code block",
+      "heading": "Heading",
+      "image_alt": "image description",
+      "image_url": "https://example.com/image.png",
+      "italic": "italic text",
+      "link_text": "link text",
+      "link_url": "https://example.com",
+      "list_item": "List item",
+      "quote": "Quote"
+    },
+    "toolbar": {
+      "bold": "Bold",
+      "code_block": "Code block",
+      "heading": "Heading",
+      "horizontal_rule": "Horizontal rule",
+      "image": "Image link",
+      "inline_code": "Inline code",
+      "italic": "Italic",
+      "label": "Markdown toolbar",
+      "link": "Link",
+      "ordered_list": "Ordered list",
+      "quote": "Quote",
+      "unordered_list": "Unordered list",
+      "upload_image": "Upload image"
+    }
+  },
   "error": {
     "api_url": "API_URL in Pages environment variables should be the Worker address. Please check if API_URL in Pages environment variables is correct.",
     "api_url_slash": "API_URL in Pages environment variables should be the Worker address. Please check if API_URL in Pages environment variables is correct and ensure API_URL does not end with a slash (/).",

--- a/client/public/locales/ja/translation.json
+++ b/client/public/locales/ja/translation.json
@@ -133,6 +133,36 @@
   "draft": "下書き",
   "draft_bin": "下書き",
   "edit": "編集",
+  "markdown_editor": {
+    "placeholder": {
+      "bold": "太字テキスト",
+      "code": "コード",
+      "code_block": "コードブロック",
+      "heading": "見出し",
+      "image_alt": "画像の説明",
+      "image_url": "https://example.com/image.png",
+      "italic": "斜体テキスト",
+      "link_text": "リンクテキスト",
+      "link_url": "https://example.com",
+      "list_item": "リスト項目",
+      "quote": "引用"
+    },
+    "toolbar": {
+      "bold": "太字",
+      "code_block": "コードブロック",
+      "heading": "見出し",
+      "horizontal_rule": "区切り線",
+      "image": "画像リンク",
+      "inline_code": "インラインコード",
+      "italic": "斜体",
+      "label": "Markdown ツールバー",
+      "link": "リンク",
+      "ordered_list": "番号付きリスト",
+      "quote": "引用",
+      "unordered_list": "箇条書き",
+      "upload_image": "画像をアップロード"
+    }
+  },
   "error": {
     "api_url": "Pages 環境変数のAPI_URLはWorkerアドレスである必要があります。Pages環境変数のAPI_URLが正しいか確認してください。",
     "api_url_slash": "Pages 環境変数のAPI_URLはWorkerアドレスである必要があります。Pages環境変数のAPI_URLが正しいか、またAPI_URLの末尾にスラッシュ（/）がないか確認してください。",

--- a/client/public/locales/zh-CN/translation.json
+++ b/client/public/locales/zh-CN/translation.json
@@ -133,6 +133,36 @@
   "draft": "草稿",
   "draft_bin": "草稿箱",
   "edit": "编辑",
+  "markdown_editor": {
+    "placeholder": {
+      "bold": "加粗文字",
+      "code": "代码",
+      "code_block": "代码块",
+      "heading": "标题",
+      "image_alt": "图片描述",
+      "image_url": "https://example.com/image.png",
+      "italic": "斜体文字",
+      "link_text": "链接文字",
+      "link_url": "https://example.com",
+      "list_item": "列表项",
+      "quote": "引用内容"
+    },
+    "toolbar": {
+      "bold": "加粗",
+      "code_block": "代码块",
+      "heading": "标题",
+      "horizontal_rule": "分割线",
+      "image": "图片链接",
+      "inline_code": "行内代码",
+      "italic": "斜体",
+      "label": "Markdown 工具栏",
+      "link": "链接",
+      "ordered_list": "有序列表",
+      "quote": "引用",
+      "unordered_list": "无序列表",
+      "upload_image": "上传图片"
+    }
+  },
   "error": {
     "api_url": "Pages 环境变量中 API_URL 应为 Worker 地址，请检查 Pages 环境变量中 API_URL 是否正确",
     "api_url_slash": "Pages 环境变量中 API_URL 应为 Worker 地址，请检查 Pages 环境变量中 API_URL 是否正确，且 API_URL 末尾不能有 /",

--- a/client/public/locales/zh-TW/translation.json
+++ b/client/public/locales/zh-TW/translation.json
@@ -133,6 +133,36 @@
   "draft": "草稿",
   "draft_bin": "草稿箱",
   "edit": "編輯",
+  "markdown_editor": {
+    "placeholder": {
+      "bold": "粗體文字",
+      "code": "程式碼",
+      "code_block": "程式碼區塊",
+      "heading": "標題",
+      "image_alt": "圖片描述",
+      "image_url": "https://example.com/image.png",
+      "italic": "斜體文字",
+      "link_text": "連結文字",
+      "link_url": "https://example.com",
+      "list_item": "列表項目",
+      "quote": "引用內容"
+    },
+    "toolbar": {
+      "bold": "粗體",
+      "code_block": "程式碼區塊",
+      "heading": "標題",
+      "horizontal_rule": "分隔線",
+      "image": "圖片連結",
+      "inline_code": "行內程式碼",
+      "italic": "斜體",
+      "label": "Markdown 工具列",
+      "link": "連結",
+      "ordered_list": "有序列表",
+      "quote": "引用",
+      "unordered_list": "無序列表",
+      "upload_image": "上傳圖片"
+    }
+  },
   "error": {
     "api_url": "Pages 環境變數中 API_URL 應為 Worker 地址，請檢查 Pages 環境變數中 API_URL 是否正確",
     "api_url_slash": "Pages 環境變數中 API_URL 應為 Worker 地址，請檢查 Pages 環境變數中 API_URL 是否正確，且 API_URL 末尾不能有 /",

--- a/client/src/components/markdown_editor.tsx
+++ b/client/src/components/markdown_editor.tsx
@@ -1,5 +1,5 @@
 import Editor from '@monaco-editor/react';
-import { editor } from 'monaco-editor';
+import { editor, Range, Selection } from 'monaco-editor';
 import React, { useRef, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import Loading from 'react-loading';
@@ -15,6 +15,54 @@ interface MarkdownEditorProps {
   setContent: (content: string) => void;
   placeholder?: string;
   height?: string;
+}
+
+type EditorPosition = {
+  lineNumber: number;
+  column: number;
+};
+
+function positionAfterText(startLineNumber: number, startColumn: number, text: string): EditorPosition {
+  const lines = text.split("\n");
+
+  if (lines.length === 1) {
+    return {
+      lineNumber: startLineNumber,
+      column: startColumn + text.length,
+    };
+  }
+
+  return {
+    lineNumber: startLineNumber + lines.length - 1,
+    column: lines[lines.length - 1].length + 1,
+  };
+}
+
+function MarkdownToolButton({
+  label,
+  icon,
+  onClick,
+  disabled = false,
+}: {
+  label: string;
+  icon: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onClick}
+      className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-transparent text-lg t-secondary transition-colors hover:border-black/10 hover:bg-neutral-100 hover:text-black focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-theme disabled:cursor-not-allowed disabled:opacity-50 dark:hover:border-white/10 dark:hover:bg-neutral-700 dark:hover:text-white sm:h-10 sm:w-10"
+    >
+      <i className={icon} aria-hidden="true" />
+      <span className="sr-only">{label}</span>
+    </button>
+  );
 }
 
 export function MarkdownEditor({ content, setContent, placeholder = "> Write your content here...", height = "400px" }: MarkdownEditorProps) {
@@ -49,6 +97,197 @@ export function MarkdownEditor({ content, setContent, placeholder = "> Write you
     }
   }
 
+  const getEditorAndSelection = () => {
+    const editorInstance = editorRef.current;
+    const model = editorInstance?.getModel();
+    const selection = editorInstance?.getSelection();
+
+    if (!editorInstance || !model || !selection) {
+      return null;
+    }
+
+    return { editorInstance, model, selection };
+  };
+
+  const replaceSelection = (selection: Selection, text: string, nextSelection?: Selection) => {
+    const editorInstance = editorRef.current;
+    if (!editorInstance) return;
+
+    editorInstance.executeEdits("markdown-toolbar", [{
+      range: selection,
+      text,
+      forceMoveMarkers: true,
+    }]);
+    setContent(editorInstance.getValue());
+
+    if (nextSelection) {
+      editorInstance.setSelection(nextSelection);
+    } else {
+      const position = positionAfterText(selection.startLineNumber, selection.startColumn, text);
+      editorInstance.setPosition(position);
+    }
+
+    editorInstance.focus();
+  };
+
+  const wrapSelection = (prefix: string, suffix: string, fallback: string) => {
+    const editorState = getEditorAndSelection();
+    if (!editorState) return;
+
+    const { model, selection } = editorState;
+    const selectedText = model.getValueInRange(selection);
+    const innerText = selectedText || fallback;
+    const insertedText = `${prefix}${innerText}${suffix}`;
+    const innerStart = positionAfterText(selection.startLineNumber, selection.startColumn, prefix);
+    const innerEnd = positionAfterText(innerStart.lineNumber, innerStart.column, innerText);
+    const end = positionAfterText(selection.startLineNumber, selection.startColumn, insertedText);
+    const nextSelection = selectedText
+      ? new Selection(end.lineNumber, end.column, end.lineNumber, end.column)
+      : new Selection(innerStart.lineNumber, innerStart.column, innerEnd.lineNumber, innerEnd.column);
+
+    replaceSelection(selection, insertedText, nextSelection);
+  };
+
+  const insertLink = () => {
+    const editorState = getEditorAndSelection();
+    if (!editorState) return;
+
+    const { model, selection } = editorState;
+    const selectedText = model.getValueInRange(selection);
+    const label = selectedText || t("markdown_editor.placeholder.link_text");
+    const url = t("markdown_editor.placeholder.link_url");
+    const prefix = `[${label}](`;
+    const insertedText = `${prefix}${url})`;
+    const urlStart = positionAfterText(selection.startLineNumber, selection.startColumn, prefix);
+    const urlEnd = positionAfterText(urlStart.lineNumber, urlStart.column, url);
+
+    replaceSelection(selection, insertedText, new Selection(urlStart.lineNumber, urlStart.column, urlEnd.lineNumber, urlEnd.column));
+  };
+
+  const insertMarkdownImage = () => {
+    const editorState = getEditorAndSelection();
+    if (!editorState) return;
+
+    const { model, selection } = editorState;
+    const selectedText = model.getValueInRange(selection);
+    const alt = selectedText || t("markdown_editor.placeholder.image_alt");
+    const url = t("markdown_editor.placeholder.image_url");
+    const prefix = `![${alt}](`;
+    const insertedText = `${prefix}${url})`;
+    const urlStart = positionAfterText(selection.startLineNumber, selection.startColumn, prefix);
+    const urlEnd = positionAfterText(urlStart.lineNumber, urlStart.column, url);
+
+    replaceSelection(selection, insertedText, new Selection(urlStart.lineNumber, urlStart.column, urlEnd.lineNumber, urlEnd.column));
+  };
+
+  const insertCodeBlock = () => {
+    const editorState = getEditorAndSelection();
+    if (!editorState) return;
+
+    const { model, selection } = editorState;
+    const selectedText = model.getValueInRange(selection);
+    const innerText = selectedText || t("markdown_editor.placeholder.code_block");
+    const prefix = "```\n";
+    const insertedText = `${prefix}${innerText}\n\`\`\``;
+    const innerStart = positionAfterText(selection.startLineNumber, selection.startColumn, prefix);
+    const innerEnd = positionAfterText(innerStart.lineNumber, innerStart.column, innerText);
+    const end = positionAfterText(selection.startLineNumber, selection.startColumn, insertedText);
+    const nextSelection = selectedText
+      ? new Selection(end.lineNumber, end.column, end.lineNumber, end.column)
+      : new Selection(innerStart.lineNumber, innerStart.column, innerEnd.lineNumber, innerEnd.column);
+
+    replaceSelection(selection, insertedText, nextSelection);
+  };
+
+  const insertHorizontalRule = () => {
+    const editorState = getEditorAndSelection();
+    if (!editorState) return;
+
+    replaceSelection(editorState.selection, "\n---\n");
+  };
+
+  const formatSelectedLines = (
+    formatter: (line: string, index: number) => string,
+    emptyLineFallback: string,
+  ) => {
+    const editorState = getEditorAndSelection();
+    if (!editorState) return;
+
+    const { editorInstance, model, selection } = editorState;
+    const startLineNumber = selection.startLineNumber;
+    const endLineNumber = selection.endLineNumber > selection.startLineNumber && selection.endColumn === 1
+      ? selection.endLineNumber - 1
+      : selection.endLineNumber;
+    const currentLine = model.getLineContent(startLineNumber);
+    const isEmptySingleLine = selection.isEmpty() && currentLine.trim().length === 0;
+    const lines = isEmptySingleLine
+      ? [emptyLineFallback]
+      : Array.from({ length: endLineNumber - startLineNumber + 1 }, (_, index) => {
+        const lineNumber = startLineNumber + index;
+        return formatter(model.getLineContent(lineNumber), index);
+      });
+    const targetEndLine = isEmptySingleLine ? startLineNumber : endLineNumber;
+    const range = new Range(
+      startLineNumber,
+      1,
+      targetEndLine,
+      model.getLineMaxColumn(targetEndLine),
+    );
+    const insertedText = lines.join("\n");
+    const end = positionAfterText(startLineNumber, 1, insertedText);
+
+    editorInstance.executeEdits("markdown-toolbar", [{
+      range,
+      text: insertedText,
+      forceMoveMarkers: true,
+    }]);
+    setContent(editorInstance.getValue());
+    editorInstance.setPosition(end);
+    editorInstance.focus();
+  };
+
+  const formatHeading = () => {
+    formatSelectedLines(
+      (line) => line.startsWith("#") ? `## ${line.replace(/^#+\s*/, "")}` : `## ${line}`,
+      `## ${t("markdown_editor.placeholder.heading")}`,
+    );
+  };
+
+  const formatQuote = () => {
+    formatSelectedLines(
+      (line) => line.startsWith("> ") ? line : `> ${line}`,
+      `> ${t("markdown_editor.placeholder.quote")}`,
+    );
+  };
+
+  const formatUnorderedList = () => {
+    formatSelectedLines(
+      (line) => line.match(/^\s*[-*]\s/) ? line : `- ${line}`,
+      `- ${t("markdown_editor.placeholder.list_item")}`,
+    );
+  };
+
+  const formatOrderedList = () => {
+    formatSelectedLines(
+      (line, index) => line.match(/^\s*\d+\.\s/) ? line : `${index + 1}. ${line}`,
+      `1. ${t("markdown_editor.placeholder.list_item")}`,
+    );
+  };
+
+  const markdownActions = [
+    { key: "heading", icon: "ri-heading", label: t("markdown_editor.toolbar.heading"), onClick: formatHeading },
+    { key: "bold", icon: "ri-bold", label: t("markdown_editor.toolbar.bold"), onClick: () => wrapSelection("**", "**", t("markdown_editor.placeholder.bold")) },
+    { key: "italic", icon: "ri-italic", label: t("markdown_editor.toolbar.italic"), onClick: () => wrapSelection("*", "*", t("markdown_editor.placeholder.italic")) },
+    { key: "link", icon: "ri-link", label: t("markdown_editor.toolbar.link"), onClick: insertLink },
+    { key: "image", icon: "ri-image-line", label: t("markdown_editor.toolbar.image"), onClick: insertMarkdownImage },
+    { key: "quote", icon: "ri-double-quotes-l", label: t("markdown_editor.toolbar.quote"), onClick: formatQuote },
+    { key: "unordered-list", icon: "ri-list-unordered", label: t("markdown_editor.toolbar.unordered_list"), onClick: formatUnorderedList },
+    { key: "ordered-list", icon: "ri-list-ordered", label: t("markdown_editor.toolbar.ordered_list"), onClick: formatOrderedList },
+    { key: "inline-code", icon: "ri-code-s-slash-line", label: t("markdown_editor.toolbar.inline_code"), onClick: () => wrapSelection("`", "`", t("markdown_editor.placeholder.code")) },
+    { key: "code-block", icon: "ri-code-box-line", label: t("markdown_editor.toolbar.code_block"), onClick: insertCodeBlock },
+    { key: "horizontal-rule", icon: "ri-separator", label: t("markdown_editor.toolbar.horizontal_rule"), onClick: insertHorizontalRule },
+  ];
+
   const handlePaste = async (event: React.ClipboardEvent<HTMLDivElement>) => {
     const clipboardData = event.clipboardData;
     if (clipboardData.files.length === 1) {
@@ -70,10 +309,14 @@ export function MarkdownEditor({ content, setContent, placeholder = "> Write you
 
   function UploadImageButton() {
     const uploadRef = useRef<HTMLInputElement>(null);
+    const label = t("markdown_editor.toolbar.upload_image");
     
-    const upChange = (event: any) => {
-      for (let i = 0; i < event.currentTarget.files.length; i++) {
-        const file = event.currentTarget.files[i];
+    const upChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = event.currentTarget.files;
+      if (!files) return;
+
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i];
         if (file.size > 5 * 1024000) {
           showAlert(t("upload.failed$size", { size: 5 }));
           uploadRef.current!.value = "";
@@ -91,11 +334,7 @@ export function MarkdownEditor({ content, setContent, placeholder = "> Write you
     };
     
     return (
-      <button
-        type="button"
-        onClick={() => uploadRef.current?.click()}
-        className="inline-flex items-center gap-2 rounded-xl border border-black/10 bg-w px-3 py-2 text-sm t-primary transition-colors hover:border-black/20 dark:border-white/10 dark:hover:border-white/20"
-      >
+      <>
         <input
           ref={uploadRef}
           onChange={upChange}
@@ -103,9 +342,13 @@ export function MarkdownEditor({ content, setContent, placeholder = "> Write you
           type="file"
           accept="image/gif,image/jpeg,image/jpg,image/png"
         />
-        <i className="ri-image-add-line" />
-        <span>Image</span>
-      </button>
+        <MarkdownToolButton
+          label={label}
+          icon="ri-image-add-line"
+          disabled={uploading}
+          onClick={() => uploadRef.current?.click()}
+        />
+      </>
     );
   }
 
@@ -155,14 +398,31 @@ export function MarkdownEditor({ content, setContent, placeholder = "> Write you
 
   return (
     <div className="flex flex-col gap-0 sm:gap-3">
-      <FlatInset className="flex flex-wrap items-center gap-2 border-0 border-b border-black/10 rounded-none bg-transparent p-3 dark:border-white/10">
-        <FlatTabButton active={preview === 'edit'} onClick={() => setPreview('edit')}> {t("edit")} </FlatTabButton>
-        <FlatTabButton active={preview === 'preview'} onClick={() => setPreview('preview')}> {t("preview")} </FlatTabButton>
-        <FlatTabButton active={preview === 'comparison'} onClick={() => setPreview('comparison')}> {t("comparison")} </FlatTabButton>
+      <FlatInset className="flex flex-wrap items-center gap-2 border-0 border-b border-black/10 rounded-none bg-transparent p-2 dark:border-white/10 sm:p-3">
+        <div className="flex shrink-0 flex-wrap items-center gap-1">
+          <FlatTabButton active={preview === 'edit'} onClick={() => setPreview('edit')}> {t("edit")} </FlatTabButton>
+          <FlatTabButton active={preview === 'preview'} onClick={() => setPreview('preview')}> {t("preview")} </FlatTabButton>
+          <FlatTabButton active={preview === 'comparison'} onClick={() => setPreview('comparison')}> {t("comparison")} </FlatTabButton>
+        </div>
         <div className="flex-grow" />
-        <UploadImageButton />
+        <div
+          className="flex min-w-0 flex-wrap items-center gap-1"
+          role="toolbar"
+          aria-label={t("markdown_editor.toolbar.label")}
+        >
+          {markdownActions.map((action) => (
+            <MarkdownToolButton
+              key={action.key}
+              label={action.label}
+              icon={action.icon}
+              onClick={action.onClick}
+            />
+          ))}
+          <span className="mx-1 hidden h-6 w-px bg-black/10 dark:bg-white/10 sm:block" aria-hidden="true" />
+          <UploadImageButton />
+        </div>
         {uploading &&
-          <div className="flex flex-row items-center space-x-2">
+          <div className="flex flex-row items-center space-x-2 px-2">
             <Loading type="spin" color="#FC466B" height={16} width={16} />
             <span className="text-sm text-neutral-500">{t('uploading')}</span>
           </div>


### PR DESCRIPTION
Closes FRO-7
Fixes #246
Fixes #257
Fixes #498

## Summary
- Add a Markdown formatting toolbar to the shared Monaco editor.
- Support selection-aware insertion for headings, bold, italic, links, image links, quotes, unordered lists, ordered lists, inline code, code blocks, and horizontal rules.
- Keep image upload in the toolbar and localize toolbar labels/placeholders for English, Simplified Chinese, Traditional Chinese, and Japanese.

## Verification
- `bun --filter './client' test`
- `bun --filter './client' check`
- `bun --filter './client' build`
- `jq empty client/public/locales/en/translation.json client/public/locales/zh-CN/translation.json client/public/locales/zh-TW/translation.json client/public/locales/ja/translation.json`
- `bunx eslint src/components/markdown_editor.tsx --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- `cd server && bun run test`
- `cd server && bun run check`
- `bun run check`
- `bun run format:check`

Note: `bun --filter './client' lint` still reports existing repo-wide lint issues outside this change; the edited editor file passes targeted ESLint.
